### PR TITLE
Changes to templates and other files re #19

### DIFF
--- a/files/TEMPLATE_ASSEMBLY.adoc
+++ b/files/TEMPLATE_ASSEMBLY.adoc
@@ -1,7 +1,12 @@
+// Module included in the following assemblies:
+//
+// <List assemblies here, each on a new line>
+
+
 // Include an 'ID' that corresponds to the title of the assembly
 // The ID will be used as an anchor for linking to the title
 // Do not change the ID to make sure existing links keep working
-[#doing_several_tasks_in_sequence]
+[#doing-several-tasks-in-sequence_{context}]
 = Doing Several Tasks in Sequence
 
 _Start the title with a verb in the gerund form, such as Creating or Configuring._

--- a/files/TEMPLATE_CONCEPT_concept-template-and-guidelines.adoc
+++ b/files/TEMPLATE_CONCEPT_concept-template-and-guidelines.adoc
@@ -1,7 +1,12 @@
+// Module included in the following assemblies:
+//
+// <List assemblies here, each on a new line>
+
+
 // Include an 'ID' that corresponds to the title of the assembly
 // The ID will be used as an anchor for linking to the title
 // Do not change the ID to make sure existing links keep working
-[#concept_template_and_guidelines]
+[#concept-template-and-guidelines_{context}]
 = Concept Template and Guidelines
 
 _In the title, include nouns that are used in the body text -- this helps readers and search engines find information quickly._

--- a/files/TEMPLATE_PROCEDURE_doing-one-procedure.adoc
+++ b/files/TEMPLATE_PROCEDURE_doing-one-procedure.adoc
@@ -1,7 +1,12 @@
+// Module included in the following assemblies:
+//
+// <List assemblies here, each on a new line>
+
+
 // Include an 'ID' that corresponds to the title of the assembly
 // The ID will be used as an anchor for linking to the title
 // Do not change the ID to make sure existing links keep working
-[#doing_one_task]
+[#doing-one-task_{context}]
 = Doing One Task
 
 _Start the title with a verb form, such as Creating or Create._

--- a/files/TEMPLATE_REFERENCE_reference-template-and-guidelines.adoc
+++ b/files/TEMPLATE_REFERENCE_reference-template-and-guidelines.adoc
@@ -1,7 +1,12 @@
+// Module included in the following assemblies:
+//
+// <List assemblies here, each on a new line>
+
+
 // Include an 'ID' that corresponds to the title of the assembly
 // The ID will be used as an anchor for linking to the title
 // Do not change the ID to make sure existing links keep working
-[#reference_template_and_guidelines]
+[#reference-template-and-guidelines_{context}]
 = Reference Template and Guidelines
 
 _In the title, include nouns that are used in the body text — this helps readers and search engines find information quickly._

--- a/files/TEMPLATE_TROUBLESHOOTING.adoc
+++ b/files/TEMPLATE_TROUBLESHOOTING.adoc
@@ -1,4 +1,9 @@
-[[troubleshooting-module-guidelines]]
+// Module included in the following assemblies:
+//
+// <List assemblies here, each on a new line>
+
+
+[#troubleshooting-module-guidelines_{context}]
 === Troubleshooting Module Guidelines
 
 Start the module with a more detailed description of how the problem presents itself. Help the reader make sure that this is the problem they are experiencing. Describe the symptoms of the problem: for example, what error messsages are displayed?

--- a/modular-docs-manual/content/topics/assembly_creating_procedure_modules.adoc
+++ b/modular-docs-manual/content/topics/assembly_creating_procedure_modules.adoc
@@ -9,5 +9,5 @@ include::module_guidelines-procedure.adoc[leveloffset=+1]
 
 == Additional Resources
 
-* Download the link:https://gitlab.cee.redhat.com/ccs-internal-documentation/Modular_Documentation_Project/raw/master/files/TEMPLATE_PROCEDURE_doing_one_procedure.adoc[procedure module template (adoc file)] for new projects.
+* Download the link:https://gitlab.cee.redhat.com/ccs-internal-documentation/Modular_Documentation_Project/raw/master/files/TEMPLATE_PROCEDURE_doing-one-procedure.adoc[procedure module template (adoc file)] for new projects.
 * For real-world examples of procedure modules, see <<modular-docs-procedure-examples>>.

--- a/modular-docs-manual/content/topics/assembly_creating_procedure_modules.adoc
+++ b/modular-docs-manual/content/topics/assembly_creating_procedure_modules.adoc
@@ -1,4 +1,4 @@
-[[creating-procedure-modules]]
+[#creating-procedure-modules]
 = Creating Procedure Modules
 
 This section explains what a procedure module is and provides recommended practices for writing procedure modules.

--- a/modular-docs-manual/content/topics/assembly_mod-docs-conversion.adoc
+++ b/modular-docs-manual/content/topics/assembly_mod-docs-conversion.adoc
@@ -1,4 +1,4 @@
-[[converting-to-mod-doc]]
+[#converting-to-mod-doc]
 = Converting to Modular Documentation
 
 If you have a monolithic, feature-based manual, you can convert it to a set of modular content based on user stories. This conversion workflow involves using the customer product lifecycle to define user stories for your product, and creating the assemblies and modules necessary to fit each user story.

--- a/modular-docs-manual/content/topics/assembly_mod-docs-examples.adoc
+++ b/modular-docs-manual/content/topics/assembly_mod-docs-examples.adoc
@@ -1,4 +1,4 @@
-[[appendix-examples]]
+[#appendix-examples]
 = Module and Assembly Examples
 
 include::module_mod-docs-concept-examples.adoc[leveloffset=+1]

--- a/modular-docs-manual/content/topics/assembly_writing-mod-docs.adoc
+++ b/modular-docs-manual/content/topics/assembly_writing-mod-docs.adoc
@@ -1,4 +1,4 @@
-[[writing-mod-docs]]
+[#writing-mod-docs]
 = Writing Modular Documentation
 
 Assemblies can include various types of modules. Use the instructions in the following sections to create modules and combine them into assemblies.

--- a/modular-docs-manual/content/topics/introduction.adoc
+++ b/modular-docs-manual/content/topics/introduction.adoc
@@ -1,4 +1,4 @@
-[[introduction]]
+[#introduction]
 = Introduction
 
 This manual provides instructions on how to author modularly structured documentation based on user stories. The manual defines used terminology, describes components that form modular documentation, and instructs writers on how to use provided templates to turn user stories into modular documentation.

--- a/modular-docs-manual/content/topics/module_auditing.adoc
+++ b/modular-docs-manual/content/topics/module_auditing.adoc
@@ -1,4 +1,4 @@
-[[auditing]]
+[#auditing]
 = Auditing Your Feature-Based Manual
 
 In the process of adding content to the modules from your existing feature-based manual, it is likely that there is some existing content that did not fit into any of the user stories that you identified and thus was not pulled out. It is important to identify this content to ensure that it is no longer needed.

--- a/modular-docs-manual/content/topics/module_creating-assemblies.adoc
+++ b/modular-docs-manual/content/topics/module_creating-assemblies.adoc
@@ -1,4 +1,4 @@
-[[creating-assemblies]]
+[#creating-assemblies]
 = Creating Assemblies
 
 An assembly is a representation of a user story, so you need to create an assembly for each user story that you defined.

--- a/modular-docs-manual/content/topics/module_creating-modules.adoc
+++ b/modular-docs-manual/content/topics/module_creating-modules.adoc
@@ -1,4 +1,4 @@
-[[creating-modules]]
+[#creating-modules]
 = Creating Modules
 
 After identifying and creating the assemblies, each assembly should identify the modules that you need to create.

--- a/modular-docs-manual/content/topics/module_customer-product-lifecycle.adoc
+++ b/modular-docs-manual/content/topics/module_customer-product-lifecycle.adoc
@@ -1,4 +1,4 @@
-[[customer-product-lifecycle]]
+[#customer-product-lifecycle]
 = Overview of the Customer Product Lifecycle
 
 User stories are the basis of modular documentation. The modular documentation conversion workflow uses the _customer product lifecycle_ to help you discover and develop the user stories that your documentation should include.

--- a/modular-docs-manual/content/topics/module_defining-user-stories.adoc
+++ b/modular-docs-manual/content/topics/module_defining-user-stories.adoc
@@ -1,4 +1,4 @@
-[[defining-user-stories]]
+[#defining-user-stories]
 = Defining User Stories for Your Product
 
 User stories provide the context and structure from which you can determine which assemblies and modules to create.

--- a/modular-docs-manual/content/topics/module_definition-procedure.adoc
+++ b/modular-docs-manual/content/topics/module_definition-procedure.adoc
@@ -1,4 +1,4 @@
-[[procedure-module-definition]]
+[#procedure-module-definition]
 = Procedure Module Definition
 
 A procedure module is a "do" module. It gives the user numbered, step-by-step instructions.

--- a/modular-docs-manual/content/topics/module_guidelines-assembly.adoc
+++ b/modular-docs-manual/content/topics/module_guidelines-assembly.adoc
@@ -1,4 +1,4 @@
-[[assembly-guidelines]]
+[#assembly-guidelines]
 = Assembly Guidelines
 
 An assembly is a collection of modules that describes how to accomplish a user story.

--- a/modular-docs-manual/content/topics/module_guidelines-concept.adoc
+++ b/modular-docs-manual/content/topics/module_guidelines-concept.adoc
@@ -1,4 +1,4 @@
-[[concept-module-guidelines]]
+[#concept-module-guidelines]
 = Concept Module Guidelines
 
 A concept module describes and explains things such as a product, subsystem, or feature -- what a customer needs to understand to do a procedure. A concept module may also explain how things relate and interact with other things. The use of graphics and diagrams can speed up understanding of a concept.

--- a/modular-docs-manual/content/topics/module_guidelines-concept.adoc
+++ b/modular-docs-manual/content/topics/module_guidelines-concept.adoc
@@ -39,4 +39,4 @@ If necessary, you can provide a bulleted list of links to other concept, procedu
 == Related Information
 For real-world examples of concept modules, and its individual parts, see <<modular-docs-concept-examples>>.
 
-Download the link:https://gitlab.cee.redhat.com/ccs-internal-documentation/Modular_Documentation_Project/raw/master/files/TEMPLATE_CONCEPT_concept_template_and_guidelines.adoc[concept module template] for new projects.
+Download the link:https://gitlab.cee.redhat.com/ccs-internal-documentation/Modular_Documentation_Project/raw/master/files/TEMPLATE_CONCEPT_concept-template-and-guidelines.adoc[concept module template] for new projects.

--- a/modular-docs-manual/content/topics/module_guidelines-procedure.adoc
+++ b/modular-docs-manual/content/topics/module_guidelines-procedure.adoc
@@ -1,4 +1,4 @@
-[[procedure-module-guidelines]]
+[#procedure-module-guidelines]
 = Procedure Module Guidelines
 
 The required parts of a procedure module are a procedure and its introduction. Optionally, the module can also include prerequisites and additional resources.
@@ -6,7 +6,7 @@ The required parts of a procedure module are a procedure and its introduction. O
 .Schema of a procedure module
 image::procedure-diagram.png[]
 
-[[writing-the-introduction]]
+[#writing-the-introduction]
 .Writing the Introduction
 The introduction is a short description of the procedure. For example, it can be a lead-in sentence or an infinitive phrase (_To extract the certificate: <steps>_). See also _The IBM Style Guide_ footnoteref:[ibm-style-guide,DERESPINIS, Francis, Peter HAYWARD, Jana JENKINS, Amy LAIRD, Leslie McDONALD, Eric RADZINKSI. _The IBM style guide: conventions for writers and editors_. Upper Saddle River, NJ: IBM Press/Pearson, c2012. ISBN 0132101300.] for details on introducing procedures.
 
@@ -18,13 +18,13 @@ The introduction typically provides context for the procedure, such as:
 
 Keep the information brief and focused on what the user needs for this specific procedure. Suggested length is 1--3 sentences, but it can be longer.
 
-[[writing-prerequisites]]
+[#writing-prerequisites]
 .Writing Prerequisites
 Prerequisites are conditions that must be satisfied before the user starts the procedure. If a prerequisite is a procedure or an assembly, include a link to them. See also _The IBM Style Guide_ footnoteref:[ibm-style-guide] for details on writing prerequisites.
 
 Focus on relevant prerequisites that users might not otherwise be aware of. Do not list obvious prerequisites.
 
-[[writing-the-procedure]]
+[#writing-the-procedure]
 .Writing the Procedure
 The procedure consists of one or more steps required to complete the procedure. Each step describes one action.
 

--- a/modular-docs-manual/content/topics/module_guidelines-reference.adoc
+++ b/modular-docs-manual/content/topics/module_guidelines-reference.adoc
@@ -1,4 +1,4 @@
-[[reference-module-guidelines]]
+[#reference-module-guidelines]
 = Reference Module Guidelines
 
 A reference module lists things, such as a list of commands, or has a very regimented structure, such as the consistent structure of man pages. A reference module explains the details that a customer needs to know to do a procedure. A reference module is well-organized if users can scan it quickly to find the details they want.

--- a/modular-docs-manual/content/topics/module_mod-docs-assembly-examples.adoc
+++ b/modular-docs-manual/content/topics/module_mod-docs-assembly-examples.adoc
@@ -1,4 +1,4 @@
-[[modular-docs-assembly-examples]]
+[#modular-docs-assembly-examples]
 = Assembly Examples
 
 .Assembly Example: Backing up an MBaaS

--- a/modular-docs-manual/content/topics/module_mod-docs-concept-examples.adoc
+++ b/modular-docs-manual/content/topics/module_mod-docs-concept-examples.adoc
@@ -1,4 +1,4 @@
-[[modular-docs-concept-examples]]
+[#modular-docs-concept-examples]
 = Concept Module Examples
 
 .Concept Module: How Ceph Works with Satellite 5

--- a/modular-docs-manual/content/topics/module_mod-docs-procedure-examples.adoc
+++ b/modular-docs-manual/content/topics/module_mod-docs-procedure-examples.adoc
@@ -1,4 +1,4 @@
-[[modular-docs-procedure-examples]]
+[#modular-docs-procedure-examples]
 = Procedure Module Examples
 
 .Procedure Module: Installing Third-Party Certificates for HTTP or LDAP

--- a/modular-docs-manual/content/topics/module_mod-docs-terms-definitions.adoc
+++ b/modular-docs-manual/content/topics/module_mod-docs-terms-definitions.adoc
@@ -1,4 +1,4 @@
-[[modular-docs-terms-definitions]]
+[#modular-docs-terms-definitions]
 = Modular Documentation Terms and Definitions
 
 Assembly:: A collection of several modules combined into a larger piece of text, preceded by an introduction that explains the purpose of the assembly.


### PR DESCRIPTION
I have made some further changes to #19 that I think should be incorporated:

* The templates now contain the reusable IDs and the comment section. I think it is valuable to promote using `:context` even where not strictly necessary because upon reuse, the ID of the module does not change, therefore we don't break existing links.
* I have changed the IDs in the existing source files to incorporate the new guidelines.

Questions:

* Should I also rename the templates? They use underscores instead of dashes now. I'm afraid I could break some external links if there are any, though.