### PR TITLE
Fix template links

### DIFF
--- a/modular-docs-manual/content/topics/assembly_creating_concept_modules.adoc
+++ b/modular-docs-manual/content/topics/assembly_creating_concept_modules.adoc
@@ -7,7 +7,7 @@ include::module_definition-concept.adoc[leveloffset=+1]
 
 include::module_guidelines-concept.adoc[leveloffset=+1]
 
-== Related Information
+== Additional Resources
 
-* Download the link:https://github.com/redhat-documentation/modular-docs/blob/master/files/TEMPLATE_CONCEPT_concept_template_and_guidelines.adoc[concept module template (adoc file)] for new projects.
+* Download the link:https://raw.githubusercontent.com/redhat-documentation/modular-docs/master/files/TEMPLATE_CONCEPT_concept-template-and-guidelines.adoc[concept module template (adoc file)] for new projects.
 * For real-world examples of concept modules, see <<modular-docs-concept-examples>>.

--- a/modular-docs-manual/content/topics/assembly_creating_concept_modules.adoc
+++ b/modular-docs-manual/content/topics/assembly_creating_concept_modules.adoc
@@ -9,5 +9,5 @@ include::module_guidelines-concept.adoc[leveloffset=+1]
 
 == Additional Resources
 
-* Download the link:https://raw.githubusercontent.com/redhat-documentation/modular-docs/master/files/TEMPLATE_CONCEPT_concept-template-and-guidelines.adoc[concept module template (adoc file)] for new projects.
+* Download the link:https://raw.githubusercontent.com/redhat-documentation/modular-docs/master/modular-docs-manual/files/TEMPLATE_CONCEPT_concept-template-and-guidelines.adoc[concept module template (adoc file)] for new projects.
 * For real-world examples of concept modules, see <<modular-docs-concept-examples>>.

--- a/modular-docs-manual/content/topics/assembly_creating_procedure_modules.adoc
+++ b/modular-docs-manual/content/topics/assembly_creating_procedure_modules.adoc
@@ -9,5 +9,5 @@ include::module_guidelines-procedure.adoc[leveloffset=+1]
 
 == Additional Resources
 
-* Download the link:https://raw.githubusercontent.com/redhat-documentation/modular-docs/master/files/TEMPLATE_PROCEDURE_doing-one-procedure.adoc[procedure module template (adoc file)] for new projects.
+* Download the link:https://raw.githubusercontent.com/redhat-documentation/modular-docs/master/modular-docs-manual/files/TEMPLATE_PROCEDURE_doing-one-procedure.adoc[procedure module template (adoc file)] for new projects.
 * For real-world examples of procedure modules, see <<modular-docs-procedure-examples>>.

--- a/modular-docs-manual/content/topics/assembly_creating_procedure_modules.adoc
+++ b/modular-docs-manual/content/topics/assembly_creating_procedure_modules.adoc
@@ -9,5 +9,5 @@ include::module_guidelines-procedure.adoc[leveloffset=+1]
 
 == Additional Resources
 
-* Download the link:https://gitlab.cee.redhat.com/ccs-internal-documentation/Modular_Documentation_Project/raw/master/files/TEMPLATE_PROCEDURE_doing-one-procedure.adoc[procedure module template (adoc file)] for new projects.
+* Download the link:https://raw.githubusercontent.com/redhat-documentation/modular-docs/master/files/TEMPLATE_PROCEDURE_doing-one-procedure.adoc[procedure module template (adoc file)] for new projects.
 * For real-world examples of procedure modules, see <<modular-docs-procedure-examples>>.

--- a/modular-docs-manual/content/topics/assembly_forming_assemblies.adoc
+++ b/modular-docs-manual/content/topics/assembly_forming_assemblies.adoc
@@ -9,5 +9,5 @@ include::module_guidelines-assembly.adoc[leveloffset=+1]
 
 == Additional Resources
 
-* Download the link:https://raw.githubusercontent.com/redhat-documentation/modular-docs/master/files/TEMPLATE_ASSEMBLY.adoc[assembly template (adoc file)] for new projects.
+* Download the link:https://raw.githubusercontent.com/redhat-documentation/modular-docs/master/modular-docs-manual/files/TEMPLATE_ASSEMBLY.adoc[assembly template (adoc file)] for new projects.
 * For real-world examples of assemblies, see <<modular-docs-assembly-examples>>.

--- a/modular-docs-manual/content/topics/assembly_forming_assemblies.adoc
+++ b/modular-docs-manual/content/topics/assembly_forming_assemblies.adoc
@@ -9,5 +9,5 @@ include::module_guidelines-assembly.adoc[leveloffset=+1]
 
 == Additional Resources
 
-* Download the link:https://gitlab.cee.redhat.com/ccs-internal-documentation/Modular_Documentation_Project/raw/master/files/TEMPLATE_ASSEMBLY.adoc[assembly template (adoc file)] for new projects.
+* Download the link:https://raw.githubusercontent.com/redhat-documentation/modular-docs/master/files/TEMPLATE_ASSEMBLY.adoc[assembly template (adoc file)] for new projects.
 * For real-world examples of assemblies, see <<modular-docs-assembly-examples>>.

--- a/modular-docs-manual/content/topics/module_guidelines-concept.adoc
+++ b/modular-docs-manual/content/topics/module_guidelines-concept.adoc
@@ -29,12 +29,3 @@ Do not include any instructions to perform an action, such as executing a comman
 .Writing Additional Resources
 
 The additional resources list links to other material closely related to the contents of the concept module: other documentation resources (such as assemblies or modules), instructional videos, labs, and similar resources.
-
-.Adding Additional Resources
-// [bhardest] - I don't think the latest concept module template has a section for additional resources/related links. If this section isn't useful, we can just remove it.
-If necessary, you can provide a bulleted list of links to other concept, procedure, and reference modules that are closely related to this concept. Only include items that are likely to be of immediate interest to a user, not every item that could conceivably be related.
-
-== Related Information
-For real-world examples of concept modules, and its individual parts, see <<modular-docs-concept-examples>>.
-
-Download the link:https://gitlab.cee.redhat.com/ccs-internal-documentation/Modular_Documentation_Project/raw/master/files/TEMPLATE_CONCEPT_concept-template-and-guidelines.adoc[concept module template] for new projects.

--- a/modular-docs-manual/content/topics/module_guidelines-reference.adoc
+++ b/modular-docs-manual/content/topics/module_guidelines-reference.adoc
@@ -12,4 +12,4 @@ A reference module lists things, such as a list of commands, or has a very regim
 
 == Additional Resources
 
-Download the reference module link:https://https://raw.githubusercontent.com/redhat-documentation/modular-docs/master/files/TEMPLATE_REFERENCE_reference-template-and-guidelines.adoc[template] for new projects.
+Download the reference module link:https://https://raw.githubusercontent.com/redhat-documentation/modular-docs/master/modular-docs-manual/files/TEMPLATE_REFERENCE_reference-template-and-guidelines.adoc[template] for new projects.

--- a/modular-docs-manual/content/topics/module_guidelines-reference.adoc
+++ b/modular-docs-manual/content/topics/module_guidelines-reference.adoc
@@ -10,6 +10,6 @@ A reference module lists things, such as a list of commands, or has a very regim
 
 * If you have a large volume of the same type of information to document, figure out a consistent structure into which the information details can fit, and then doument each logical unit of information as one reference module. For example, think of man pages, which document very different information details, but which still use consistent titles and formats to present those details in a consistent information structure.
 
-== Related information
+== Additional Resources
 
-Download the reference module link:https://gitlab.cee.redhat.com/ccs-internal-documentation/Modular_Documentation_Project/raw/master/files/template_reference.adoc[template] for new projects.
+Download the reference module link:https://https://raw.githubusercontent.com/redhat-documentation/modular-docs/master/files/TEMPLATE_REFERENCE_reference-template-and-guidelines.adoc[template] for new projects.


### PR DESCRIPTION
Two commits to fix what looks like a minor regression:

* Broken links (templates are available at github, not gitlab)
* A superfluous paragraph (that was moved to a different module in a previous pull request).