### PR TITLE
Review reference module resources

### DIFF
--- a/modular-docs-manual/content/topics/assembly_creating_reference_modules.adoc
+++ b/modular-docs-manual/content/topics/assembly_creating_reference_modules.adoc
@@ -1,0 +1,13 @@
+[id='creating-reference-modules']
+= Creating Reference Modules
+
+This section explains what a reference module is and provides recommended practices for writing reference modules.
+
+include::module_definition-reference.adoc[leveloffset=+1]
+
+include::module_guidelines-reference.adoc[leveloffset=+1]
+
+== Additional Resources
+
+* Download the link:https://raw.githubusercontent.com/redhat-documentation/modular-docs/master/files/TEMPLATE_REFERENCE_reference-template-and-guidelines.adoc[reference module template (adoc file)] for new projects.
+* For advice on when to use lists and when to use tables, see link:https://medium.com/@heyoka/lets-bring-table-to-the-table-again-f1ae751159d5[Let’s bring <table> to the table, again.]

--- a/modular-docs-manual/content/topics/assembly_creating_reference_modules.adoc
+++ b/modular-docs-manual/content/topics/assembly_creating_reference_modules.adoc
@@ -10,4 +10,5 @@ include::module_guidelines-reference.adoc[leveloffset=+1]
 == Additional Resources
 
 * Download the link:https://raw.githubusercontent.com/redhat-documentation/modular-docs/master/files/TEMPLATE_REFERENCE_reference-template-and-guidelines.adoc[reference module template (adoc file)] for new projects.
+* For real-world examples of reference modules, see <<modular-docs-reference-examples>>.
 * For advice on when to use lists and when to use tables, see link:https://medium.com/@heyoka/lets-bring-table-to-the-table-again-f1ae751159d5[Let’s bring <table> to the table, again.]

--- a/modular-docs-manual/content/topics/assembly_creating_reference_modules.adoc
+++ b/modular-docs-manual/content/topics/assembly_creating_reference_modules.adoc
@@ -9,6 +9,6 @@ include::module_guidelines-reference.adoc[leveloffset=+1]
 
 == Additional Resources
 
-* Download the link:https://raw.githubusercontent.com/redhat-documentation/modular-docs/master/files/TEMPLATE_REFERENCE_reference-template-and-guidelines.adoc[reference module template (adoc file)] for new projects.
+* Download the link:https://raw.githubusercontent.com/redhat-documentation/modular-docs/master/modular-docs-manual/files/TEMPLATE_REFERENCE_reference-template-and-guidelines.adoc[reference module template (adoc file)] for new projects.
 * For real-world examples of reference modules, see <<modular-docs-reference-examples>>.
 * For advice on when to use lists and when to use tables, see link:https://medium.com/@heyoka/lets-bring-table-to-the-table-again-f1ae751159d5[Let’s bring <table> to the table, again.]

--- a/modular-docs-manual/content/topics/assembly_mod-docs-examples.adoc
+++ b/modular-docs-manual/content/topics/assembly_mod-docs-examples.adoc
@@ -5,4 +5,6 @@ include::module_mod-docs-concept-examples.adoc[leveloffset=+1]
 
 include::module_mod-docs-procedure-examples.adoc[leveloffset=+1]
 
+include::module_mod-docs-reference-examples.adoc[leveloffset=+1]
+
 include::module_mod-docs-assembly-examples.adoc[leveloffset=+1]

--- a/modular-docs-manual/content/topics/assembly_writing-mod-docs.adoc
+++ b/modular-docs-manual/content/topics/assembly_writing-mod-docs.adoc
@@ -18,7 +18,7 @@ include::assembly_creating_concept_modules.adoc[leveloffset=+2]
 
 include::assembly_creating_procedure_modules.adoc[leveloffset=+2]
 
-include::module_guidelines-reference.adoc[leveloffset=+2]
+include::assembly_creating_reference_modules.adoc[leveloffset=+2]
 
 include::module_anchor-and-file-names-concept.adoc[leveloffset=+2]
 

--- a/modular-docs-manual/content/topics/module_definition-reference.adoc
+++ b/modular-docs-manual/content/topics/module_definition-reference.adoc
@@ -1,0 +1,30 @@
+[id='reference-module-definition']
+= Reference Module Definition
+
+Reference modules provide data that users might want to look up, but do not need to remember.
+
+.Common documentation examples of reference modules
+====
+* A list of commands that users can use with an application
+* A table of configuration files with definitions and usage examples
+* A list of default settings for a product
+====
+
+.Reference modules explained using a real-life example
+====
+For documentation on how to cross the road, you could create these modules:
+
+* Concept modules:
+** What are roads
+** What are crossings
+
+* Procedure modules:
+** How to put one foot in front of another
+** How to use pedestrian traffic lights
+** How to see if the road is clear for crossing
+
+* Reference modules:
+** Crossing signals
+** Common crosswalk pavement markings
+** Crossing laws by country
+====

--- a/modular-docs-manual/content/topics/module_guidelines-reference.adoc
+++ b/modular-docs-manual/content/topics/module_guidelines-reference.adoc
@@ -11,11 +11,11 @@ The introduction to a reference module is a single, concise paragraph that provi
 [discrete]
 == Writing the Reference
 
-A reference module has a very regimented structure, often in the form of a list or a table. A well-organized reference module enables users to scan it quickly to find the details they want.
+A reference module has a very strict structure, often in the form of a list or a table. A well-organized reference module enables users to scan it quickly to find the details they want.
 
 To make the reference data easier to scan, organize it in a logical order (such as alphabetically) or as a table. AsciiDoc markup to consider for reference data:
 
 * link:http://asciidoctor.org/docs/asciidoc-syntax-quick-reference/#lists[Lists] (unordered, labeled)
 * link:http://asciidoctor.org/docs/asciidoc-syntax-quick-reference/#tables[Tables]
 
-If you have a large volume of the same type of information to document, figure out a consistent structure into which the information details can fit, and then document each logical unit of information as one reference module. For example, think of man pages, which document very different information details, but which still use consistent titles and formats to present those details in a consistent information structure.
+If you have a large volume of the same type of information to document, use a structure into which the information details can fit, and then document each logical unit of information as one reference module. For example, think of man pages, which document very different information details, but which still use consistent titles and formats to present those details in a uniform information structure.

--- a/modular-docs-manual/content/topics/module_guidelines-reference.adoc
+++ b/modular-docs-manual/content/topics/module_guidelines-reference.adoc
@@ -1,15 +1,21 @@
 [id='reference-module-guidelines']
 = Reference Module Guidelines
 
-A reference module lists things, such as a list of commands, or has a very regimented structure, such as the consistent structure of man pages. A reference module explains the details that a customer needs to know to do a procedure. A reference module is well-organized if users can scan it quickly to find the details they want.
+The required part of a reference module is the reference data. Optionally, the module can also include an introduction.
 
-//[bhardest] - We can include a diagram here if needed, similar to the concept one.
+[discrete]
+== Writing the Introduction
 
-* A reference module that is a list of things may be made easier to scan if its content is organized alphabetically or formatted as a table. Think of an alphabetical list of commands that can be used with an application, or of an alphabetical list of system components with brief definitions formatted as a 2-column table.
-// [bhardest] - This is a good use of a reference module; however, I've seen many different formats for this type of content in Red Hat product docs. It would help to provide some examples to help writers better visualize the techniques they can use to document these types of things in a clear, well-organized fashion.
+The introduction to a reference module is a single, concise paragraph that provides a short overview of the module. A short description makes the module more usable because users can quickly determine whether the reference is useful without having to read the entire module.
 
-* If you have a large volume of the same type of information to document, figure out a consistent structure into which the information details can fit, and then doument each logical unit of information as one reference module. For example, think of man pages, which document very different information details, but which still use consistent titles and formats to present those details in a consistent information structure.
+[discrete]
+== Writing the Reference
 
-== Additional Resources
+A reference module has a very regimented structure, often in the form of a list or a table. A well-organized reference module enables users to scan it quickly to find the details they want.
 
-Download the reference module link:https://https://raw.githubusercontent.com/redhat-documentation/modular-docs/master/modular-docs-manual/files/TEMPLATE_REFERENCE_reference-template-and-guidelines.adoc[template] for new projects.
+To make the reference data easier to scan, organize it in a logical order (such as alphabetically) or as a table. AsciiDoc markup to consider for reference data:
+
+* link:http://asciidoctor.org/docs/asciidoc-syntax-quick-reference/#lists[Lists] (unordered, labeled)
+* link:http://asciidoctor.org/docs/asciidoc-syntax-quick-reference/#tables[Tables]
+
+If you have a large volume of the same type of information to document, figure out a consistent structure into which the information details can fit, and then document each logical unit of information as one reference module. For example, think of man pages, which document very different information details, but which still use consistent titles and formats to present those details in a consistent information structure.

--- a/modular-docs-manual/content/topics/module_mod-docs-reference-examples.adoc
+++ b/modular-docs-manual/content/topics/module_mod-docs-reference-examples.adoc
@@ -1,0 +1,2 @@
+[id='modular-docs-reference-examples']
+= Reference Module Examples


### PR DESCRIPTION
In this pull request, I reviewed the description of reference modules. The new version matches the structure used for explaining the other modules and for assemblies: a definition first, followed by writing guidelines, and then links to useful resources.

The reference module guidelines were the trickiest for me to review because I find reference modules the most difficult to explain, but I did my best. The updated version is based on the guidelines we already had in the manual and a few conversations I've had with people over the past few months. 