### PR TITLE
Clarified instructions for headings in templates.

### DIFF
--- a/modular-docs-manual/files/TEMPLATE_CONCEPT_concept-explanation.adoc
+++ b/modular-docs-manual/files/TEMPLATE_CONCEPT_concept-explanation.adoc
@@ -11,8 +11,8 @@
 [id='concept-explanation-{context}']
 // The `context` attribute enables module reuse. Every module's ID includes {context}, which ensures that the module has a unique ID even if it is reused multiple times in a guide.
 = Concept explanation
-//In the title, include nouns that are used in the body text. This helps readers and search engines find information quickly.
-//Do not start the title with a verb. See also _Wording of headings_ in _The IBM Style Guide_.
+//In the title of concept modules, include nouns or noun phrases that are used in the body text. This helps readers and search engines find the information quickly.
+//Do not start the title of concept modules with a verb. See also _Wording of headings_ in _The IBM Style Guide_.
 
 This paragraph is the concept module introduction and is only optional. Include it to provide a short overview of the module.
 

--- a/modular-docs-manual/files/TEMPLATE_PROCEDURE_doing-one-procedure.adoc
+++ b/modular-docs-manual/files/TEMPLATE_PROCEDURE_doing-one-procedure.adoc
@@ -11,7 +11,7 @@
 [id='doing-one-procedure_{context}']
 // The `context` attribute enables module reuse. Every module's ID includes {context}, which ensures that the module has a unique ID even if it is reused multiple times in a guide.
 = Doing one procedure
-// Start the title with a verb, such as Creating or Create. See also _Wording of headings_ in _The IBM Style Guide_.
+// Start the title of a procedure module with a verb, such as Creating or Create. See also _Wording of headings_ in _The IBM Style Guide_.
 
 This paragraph is the procedure module introduction: a short description of the procedure.
 

--- a/modular-docs-manual/files/TEMPLATE_REFERENCE_reference-material.adoc
+++ b/modular-docs-manual/files/TEMPLATE_REFERENCE_reference-material.adoc
@@ -11,7 +11,7 @@
 [id='reference-material_{context}']
 // The `context` attribute enables module reuse. Every module's ID includes {context}, which ensures that the module has a unique ID even if it is reused multiple times in a guide.
 = Reference material
-//In the title, include nouns that are used in the body text. This helps readers and search engines find information quickly.
+//In the title of a reference module, include nouns that are used in the body text. For example, "Keyboard shortcuts for ___" or "Command options for ___." This helps readers and search engines find the information quickly.
 
 This paragraph is the reference module introduction and is only optional. Include it to provide a short overview of the module.
 


### PR DESCRIPTION
Minor additions to the module templates to make instructions for writing headings more explicit to the type of module.