### PR TITLE
Revert H2 section headings to block headings for procedures, prereqs, and additional resources.

### DIFF
--- a/modular-docs-manual/content/topics/assembly_mod-docs-conversion.adoc
+++ b/modular-docs-manual/content/topics/assembly_mod-docs-conversion.adoc
@@ -3,10 +3,10 @@
 
 If you have a monolithic, feature-based manual, you can convert it to a set of modular content based on user stories. This conversion workflow involves using the customer product lifecycle to define user stories for your product, and creating the assemblies and modules necessary to fit each user story.
 
-The result is documentation that is more relevant for your readers, because it is based on real-world user stories (it tells them how to accomplish their goals), and modular (it can be assembled into whatever sets and formats they might need). 
+The result is documentation that is more relevant for your readers, because it is based on real-world user stories (it tells them how to accomplish their goals), and modular (it can be assembled into whatever sets and formats they might need).
 
 
-== Prerequisites
+.Prerequisites
 
 * You should understand what modular documentation is:
 ** xref:what-modular-documentation-is[What Modular Documentation Is]

--- a/modular-docs-manual/content/topics/module_anchor-and-file-names-concept.adoc
+++ b/modular-docs-manual/content/topics/module_anchor-and-file-names-concept.adoc
@@ -51,6 +51,6 @@ File names:: Give the module file the same name as the anchor used in it (which 
 * `ref_guided-decision-table-columns.adoc`  (Reference module with column types)
 * `assembly_guided-decision-tables.adoc`  (Assembly of guided decision table modules)
 
-== Additional Resources
+.Additional Resources
 
 * The link:http://asciidoctor.org/docs/user-manual/#anchordef[Asciidoctor User Manual]

--- a/modular-docs-manual/content/topics/module_auditing.adoc
+++ b/modular-docs-manual/content/topics/module_auditing.adoc
@@ -3,8 +3,7 @@
 
 In the process of adding content to the modules from your existing feature-based manual, it is likely that there is some existing content that did not fit into any of the user stories that you identified and thus was not pulled out. It is important to identify this content to ensure that it is no longer needed.
 
-[discrete]
-== Procedure
+.Procedure
 
 . Go through your existing feature-based manual and identify any content that you did not add to an assembly or module.
 

--- a/modular-docs-manual/content/topics/module_creating-assemblies.adoc
+++ b/modular-docs-manual/content/topics/module_creating-assemblies.adoc
@@ -5,8 +5,7 @@ An assembly is a representation of a user story, so you need to create an assemb
 
 An assembly could represent an article, "chapter" in a book, or even an entire book. However, one of the benefits of modular documentation is that you do not need to worry about how the assembly will ultimately be used -- each assembly represents a user goal, and once you create it, it can be "included" anywhere it is needed (a publication, within another assembly, and so on).
 
-[discrete]
-== Procedure
+.Procedure
 
 . Create an assembly file for each user story that you identified.
 +

--- a/modular-docs-manual/content/topics/module_creating-modules.adoc
+++ b/modular-docs-manual/content/topics/module_creating-modules.adoc
@@ -3,15 +3,15 @@
 
 After identifying and creating the assemblies, each assembly should identify the modules that you need to create.
 
-[discrete]
-== Procedure
+.Procedure
 
 . For each assembly that you created, create a module file for each module that is identified in the assembly.
 +
+--
 Each assembly should already have the names of the modules that should be included in the assembly. Now you just need to create the actual files for those modules.
 
 Be sure to follow the conventions for xref:anchor-and-file-names[naming anchors and files]. For example: `con_guided-decision-tables.adoc`
-
+--
 . For each module file that you created, add content.
 +
 --

--- a/modular-docs-manual/content/topics/module_defining-user-stories.adoc
+++ b/modular-docs-manual/content/topics/module_defining-user-stories.adoc
@@ -5,12 +5,11 @@ User stories provide the context and structure from which you can determine whic
 
 For more information about user stories, see xref:modular-docs-terms-definitions[Modular Documentation Terms and Definitions].
 
-Ideally, well-defined user stories would already exist for the product you are documenting. For most writers, however, this ideal is not a reality. If you do not have any user stories from which to work, and you -- as a writer -- do not have all of the user information you would need to create the user stories yourself, how do you get started? This procedure provides a general approach that you can take. 
+Ideally, well-defined user stories would already exist for the product you are documenting. For most writers, however, this ideal is not a reality. If you do not have any user stories from which to work, and you -- as a writer -- do not have all of the user information you would need to create the user stories yourself, how do you get started? This procedure provides a general approach that you can take.
 
 Of course, every product differs in terms of tools, processes, team dynamics, and access to SMEs. Since you are most familiar with these aspects for your own team, you will need to adapt this general approach for your own team. Depending on your team structure, each step can be completed by either a writer or a collaboration between a writer and Content Strategist.
 
-[discrete]
-== Procedure
+.Procedure
 
 . Identify the key, top-level user stories for your product.
 +
@@ -56,7 +55,7 @@ Depending on the product, one or two levels of user stories might be sufficient.
 
 Be careful not to go too deep, however. At this stage, you are not defining every procedure or step needed to complete each user story. User stories represent user goals, so you should only need to go deeper if a secondary user story has multiple goals.
 
-For example, under the "Configuring Product X" example in the previous step, the logging user story does not need any additional user stories -- the goal cannot be reduced any further than it already is. On the other hand, the adding security settings user story might be able to go a bit deeper. Security is a goal in and of itself (users want their applications to be secure), but there are more specific goals users might have within it: 
+For example, under the "Configuring Product X" example in the previous step, the logging user story does not need any additional user stories -- the goal cannot be reduced any further than it already is. On the other hand, the adding security settings user story might be able to go a bit deeper. Security is a goal in and of itself (users want their applications to be secure), but there are more specific goals users might have within it:
 
 .Creating Additional User Stories
 ====
@@ -67,7 +66,7 @@ For example, under the "Configuring Product X" example in the previous step, the
 *** As a system administrator, I want to use my existing LDAP configuration so that clients can be authenticated.
 ** As a system administrator, I want to set up logging so that error conditions can be diagnosed.
 ====
--- 
+--
 
 . For each user story in your list, define the following:
 +

--- a/modular-docs-manual/content/topics/module_definition-procedure.adoc
+++ b/modular-docs-manual/content/topics/module_definition-procedure.adoc
@@ -3,4 +3,4 @@
 
 A procedure module is a "do" module. It gives the user numbered, step-by-step instructions.
 
-IMPORTANT: A procedure module does not consist solely of a procedure. At the very least, the steps must be preceded by an introduction statement that provides context for the procedure. For details, see <<writing-the-introduction>>.
+IMPORTANT: A procedure module does not consist solely of a procedure. At the very least, the steps must be preceded by an introduction statement that provides context for the procedure. For details, see <<procedure-module-guidelines>>.

--- a/modular-docs-manual/content/topics/module_guidelines-assembly.adoc
+++ b/modular-docs-manual/content/topics/module_guidelines-assembly.adoc
@@ -3,7 +3,8 @@
 
 The required parts of an assembly are the introduction and modules. Optionally, an assembly can also include prerequisites and additional resources.
 
-.Writing the Introduction
+[discrete]
+== Assembly Introduction
 
 The introduction explains what the user will accomplish by working through the assembled modules. It typically provides context for the assembly.
 
@@ -12,18 +13,22 @@ Consider rewording the user story to write the assembly introduction, for exampl
 * User story: As an administrator, I want to provide external identity, authentication and authorization services for my Atomic Host, so that users from external identity sources can access the Atomic Host.
 * Assembly introduction: As a system administrator, you can use SSSD in a container to provide external identity, authentication, and authorization services for the Atomic Host system. This enables users from external identity sources to authenticate to the Atomic Host.
 
-.Writing Prerequisites
+[discrete]
+== Assembly Prerequisites
 
-Prerequisites are conditions that must be satisfied before the user can start following the assembly. For details, see xref:writing-prerequisites[Writing Prerequisites].
+Prerequisites are conditions that must be satisfied before the user can start following the assembly.
 
 // [bhardest] - We have a lot of xref-ing in these guidelines. A better approach might be to create a "snippets" .adoc file with snippets of common content (for example, the content about writing prerequisites, which applies to multiple sections). Then we can just include the relevant content from the snippets file wherever it's needed.
 // [asteflova] - Let's do this after we finish reviewing the guidelines for procedures and assemblies.
+// [sterobin] - I removed the cross-ref to the procedure "Writing prerequisites" for now because it provided no value and the id for that linked section needed to be removed anyway (should only be linking to modules, not module sub-headings). This clearly now provides little information, but based on the above comments, we should be looking into a better structure all around in this doc for describing the prereq, intro, body components that apply universally.
 
-.Adding Modules
+[discrete]
+== Assembly Modules
 
 List link:http://asciidoctor.org/docs/asciidoc-syntax-quick-reference/#include-files[include files] to include the required modules. Use any combination of concept, procedure, and reference modules that fulfills the purpose of the assembly.
 
-.Adding Additional Resources
+[discrete]
+== Assembly Additional Resources
 
 Additional resources list links to other material closely related to the contents of the assembly: other documentation resources (such as assemblies or modules), instructional videos, labs, and similar resources.
 

--- a/modular-docs-manual/content/topics/module_guidelines-concept.adoc
+++ b/modular-docs-manual/content/topics/module_guidelines-concept.adoc
@@ -10,8 +10,8 @@ Even if a concept is interesting, it probably does not require explanation if it
 
 image::concept-diagram.png[]
 
-[id='concept-writing-the-introduction']
-.Writing the Introduction
+[discrete]
+== Concept Introduction
 
 The introduction to a concept module is a single, concise paragraph that provides a short overview of the module.
 A short description makes the module more usable because users can quickly determine whether the concept is useful without having to read the entire module.
@@ -21,10 +21,10 @@ The introduction typically answers the following questions:
 * What is the concept?
 * Why should the user care about the concept?
 
-[id='concept-writing-the-concept-explanation']
-.Writing the Concept Explanation
+[discrete]
+== Concept Body
 
-The concept explanation describes the subject of the concept module.
+The concept body describes the subject of the concept module.
 
 Apart from paragraphs, you can use other AsciiDoc elements, such as lists, tables, or examples.
 Consider including graphics or diagrams to speed up the understanding of the concept.
@@ -33,6 +33,7 @@ Do not include any instructions to perform an action, such as executing a comman
 Action items belong in procedure modules.
 See also link:http://www.informationmapping.com/fspro2013-tutorial/infotypes/infotype2.html[The Six Information Types] at _informationmapping.com_ for ways to present different types of conceptual information: principle, concept, structure, process, fact.
 
-.Writing Additional Resources
+[discrete]
+== Concept Additional Resources
 
 The additional resources list links to other material closely related to the contents of the concept module: other documentation resources (such as assemblies or modules), instructional videos, labs, and similar resources.

--- a/modular-docs-manual/content/topics/module_guidelines-procedure.adoc
+++ b/modular-docs-manual/content/topics/module_guidelines-procedure.adoc
@@ -6,8 +6,8 @@ The required parts of a procedure module are a procedure and its introduction. O
 .Schema of a procedure module
 image::procedure-diagram.png[]
 
-[id='writing-the-introduction']
-.Writing the Introduction
+[discrete]
+== Procedure Introduction
 The introduction is a short description of the procedure. For example, it can be a lead-in sentence or an infinitive phrase (_To extract the certificate: <steps>_). See also _The IBM Style Guide_ footnoteref:[ibm-style-guide,DERESPINIS, Francis, Peter HAYWARD, Jana JENKINS, Amy LAIRD, Leslie McDONALD, Eric RADZINKSI. _The IBM style guide: conventions for writers and editors_. Upper Saddle River, NJ: IBM Press/Pearson, c2012. ISBN 0132101300.] for details on introducing procedures.
 
 The introduction typically provides context for the procedure, such as:
@@ -18,19 +18,20 @@ The introduction typically provides context for the procedure, such as:
 
 Keep the information brief and focused on what the user needs for this specific procedure. Suggested length is 1--3 sentences, but it can be longer.
 
-[id='writing-prerequisites']
-.Writing Prerequisites
+[discrete]
+== Procedure Prerequisites
 Prerequisites are conditions that must be satisfied before the user starts the procedure. If a prerequisite is a procedure or an assembly, include a link to them. See also _The IBM Style Guide_ footnoteref:[ibm-style-guide] for details on writing prerequisites.
 
 Focus on relevant prerequisites that users might not otherwise be aware of. Do not list obvious prerequisites.
 
-[id='writing-the-procedure']
-.Writing the Procedure
+[discrete]
+== Procedure Body
 The procedure consists of one or more steps required to complete the procedure. Each step describes one action.
 
 For single-step procedures, use an unnumbered bullet instead of a numbered list.
 
-.Writing Additional Resources
+[discrete]
+== Procedure Additional Resources
 Additional resources list links to other material closely related to the contents of the procedure module: other documentation resources (such as assemblies or modules), instructional videos, labs, and similar resources.
 
 Focus on relevant resources that are likely to be of immediate interest to the user. Do not list every resource that could conceivably be related.

--- a/modular-docs-manual/content/topics/module_guidelines-reference.adoc
+++ b/modular-docs-manual/content/topics/module_guidelines-reference.adoc
@@ -5,12 +5,12 @@ The required part of a reference module is the reference data.
 A reference module requires a short introduction.
 
 [discrete]
-== Writing the Introduction
+== Reference Introduction
 
 The introduction to a reference module is a single, concise paragraph that provides a short overview of the module. A short description makes the module more usable because users can quickly determine whether the reference is useful without having to read the entire module.
 
 [discrete]
-== Writing the Reference
+== Reference Body
 
 A reference module has a very strict structure, often in the form of a list or a table. A well-organized reference module enables users to scan it quickly to find the details they want.
 

--- a/modular-docs-manual/content/topics/module_reusing-modules-procedure.adoc
+++ b/modular-docs-manual/content/topics/module_reusing-modules-procedure.adoc
@@ -15,7 +15,7 @@ $BUILD_PATH fails to validate
 This error is resolved by adding and defining a document variable.
 
 [discrete]
-== Procedure
+.Procedure
 
 . In the module file that will be reused, add the `+++{context}+++` suffix with an underscore to the anchor name in the format `[id='anchor-name_+++{context}'+++]`.
 
@@ -119,6 +119,12 @@ Example:
 For details, see xref:module-A-being-reused_assembly-1-name[].
 ----
 ====
+
+.Additional Resources
+
+* The link:http://asciidoctor.org/docs/user-manual/#include-multiple[Asciidoctor User Manual].
+
+// [sterobin] - I need to rework the two "Practical Examples" below to be stand-alone modules. Good candidates for reuse.
 
 [discrete]
 == Practical Example 1: Reusing Modules in Multiple Assemblies
@@ -248,8 +254,3 @@ or
 ----
 For details, see xref:projects_asset-types[].
 ----
-
-[discrete]
-== Additional Resources
-
-* The link:http://asciidoctor.org/docs/user-manual/#include-multiple[Asciidoctor User Manual].

--- a/modular-docs-manual/content/topics/module_what-modular-documentation-is.adoc
+++ b/modular-docs-manual/content/topics/module_what-modular-documentation-is.adoc
@@ -14,7 +14,6 @@ At Red Hat, we write modular documentation that is based on _user-stories_. This
 image::modules_assemblies.png[]
 // The image is just a draft, we can create a fancier one later.
 
-[discrete]
-== Additional Resources
+.Additional Resources
 
 * For definitions of the terms we use, including modules, assemblies, and user stories, see <<modular-docs-terms-definitions>>.

--- a/modular-docs-manual/files/TEMPLATE_ASSEMBLY_a-collection-of-modules.adoc
+++ b/modular-docs-manual/files/TEMPLATE_ASSEMBLY_a-collection-of-modules.adoc
@@ -22,8 +22,7 @@
 
 This paragraph is the assembly introduction. It explains what the user will accomplish by working through the modules in the assembly and sets the context for the user story the assembly is based on. Can include more than one paragraph. Consider using the information from the user story.
 
-[id='prerequisites-{context}']
-== Prerequisites
+.Prerequisites
 
 * A bulleted list of conditions that must be satisfied before the user starts following this assembly.
 * You can also link to other modules or assemblies the user must follow before starting this assembly.
@@ -36,8 +35,7 @@ include::modules/TEMPLATE_CONCEPT_explaining_a_concept.adoc[leveloffset=+1]
 
 include::modules/TEMPLATE_PROCEDURE_doing_one_procedure.adoc[leveloffset=+1]
 
-[id='additional-resources-{context}']
-== Additional resources
+== Additional resources (or Next steps)
 
 * A bulleted list of links to other material closely related to the contents of the concept module.
 * For more details on writing assemblies, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].

--- a/modular-docs-manual/files/TEMPLATE_CONCEPT_concept-explanation.adoc
+++ b/modular-docs-manual/files/TEMPLATE_CONCEPT_concept-explanation.adoc
@@ -23,8 +23,7 @@ The contents of a concept module give the user descriptions and explanations nee
 * Explain only things that are visible to users. Even if a concept is interesting, it probably does not require explanation if it is not visible to users.
 * Do not include any instructions to perform an action, such as executing a command. Action items belong in procedure modules.
 
-[discrete]
-== Additional resources
+.Additional resources
 
 * A bulleted list of links to other material closely related to the contents of the concept module.
 * For more details on writing concept modules, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].

--- a/modular-docs-manual/files/TEMPLATE_PROCEDURE_doing-one-procedure.adoc
+++ b/modular-docs-manual/files/TEMPLATE_PROCEDURE_doing-one-procedure.adoc
@@ -15,15 +15,13 @@
 
 This paragraph is the procedure module introduction: a short description of the procedure.
 
-[discrete]
-== Prerequisites
+.Prerequisites
 
 * A bulleted list of conditions that must be satisfied before the user starts following this assembly.
 * You can also link to other modules or assemblies the user must follow before starting this assembly.
 * Delete the section title and bullets if the assembly has no prerequisites.
 
-[discrete]
-== Procedure
+.Procedure
 
 . Start each step with an active verb.
 
@@ -31,8 +29,7 @@ This paragraph is the procedure module introduction: a short description of the 
 
 . Use an unnumbered bullet (*) if the procedure includes only one step.
 
-[discrete]
-== Additional Resources
+.Additional resources
 
 * A bulleted list of links to other material closely related to the contents of the procedure module.
 * For more details on writing procedure modules, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].

--- a/modular-docs-manual/files/TEMPLATE_REFERENCE_reference-material.adoc
+++ b/modular-docs-manual/files/TEMPLATE_REFERENCE_reference-material.adoc
@@ -21,16 +21,16 @@ It has a very strict structure, often in the form of a list or a table.
 A well-organized reference module enables users to scan it quickly to find the details they want.
 AsciiDoc markup to consider for reference data:
 
-.Unordered lists
+.Unordered list
 * For more details on writing reference modules, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
 * Use a consistent system for file names, IDs, and titles.
 For tips, see _Anchor Names and File Names_ in link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
 
-.Labeled lists
+.Labeled list
 Term 1:: Definition
 Term 2:: Definition
 
-.Tables
+.Table
 [options="header"]
 |====
 |Column 1|Column 2|Column 3


### PR DESCRIPTION
As discussed in ccs-mod-docs distro list with email subject "Clarification on block heading vs. sub-heading for prereqs, procedures, etc.", I've reverted Procedure, Preq, and Additional headings to previous block format in templates and Ref Guide (`.Procedure`, `.Prerequisites`, etc.) everywhere except for Additional resources in assemblies specifically, which should remain an un-discrete "== Additional resources" for now. That too can be reverted to block format once the tooling team finishes the fixes on modules and moves on to assemblies. See the considerations below. I also adjusted some structural inconsistencies in the Ref Guide while I was at it.

Summary of considerations:
- **Tooling/stylesheet solutions to the minor output glitch:** It's true that there is a minor glitch in the output when we use `.Procedure` etc. (it might vary in size slightly sometimes), and that `.Procedure` looks virtually the same as `.Table` or `.Figure` in some cases (I'd argue that they are similar types of content anyway and thus suitable as similar labels and not headings). But this is a tooling/stylesheet issue now being handled (as it should be) by the tooling team in FCC Phase 1, for modules at least. The same issue will be addressed in assemblies in a coming phase. So this workaround is no longer necessary, and even if it were, using "== Title" as the workaround seems worse than the minor glitch it's intended to replace and is not advisable anyway, for the reasons that follow.
- **Nesting scalability:** With "== Procedure", "== Prerequisites", etc., these headings vary based on the level of heading/offset of the section they're in and are not very scalable in nested content. It might look fine if it's section is H1 or H2 but if you have a "== Procedure" in a section that is an H3 in an assembly, or heaven forbid, H4, it gets ugly fast. Even despite the size issue, the fact that it varies based on where it falls is undesirable. Whereas ".Procedure" is fairly stable and more consistent throughout, despite the slight size difference at times due to tooling (better slight than drastic). For an example, see this short [Entando doc preview](http://file.rdu.redhat.com/~sterobin/BXMSDOC-ENT_BA_TEST/) and skim the "Prerequisite" and "Procedure" headings at each nested section. This document uses "== Procedure", which varies and shrinks in a distracting and unpleasant way.
- **Conceptual/semantic clarity:** As someone pointed out before, "== Title" is a section heading while ".Title" is a label. Procedures, prerequisites, and additional resources, in a modular environment, are more labels than headings imo, especially since they're repeated consistently across differently headed sections. Anything that is a heading really ought to be standalone when possible, except for genuine sub-headings in concepts and refs, but never procedures (according to the proscription). Specifics aside, I think we can agree that there is a difference between content headed "Guided decision tables" (clearly a heading) and "Procedure" (what I'd consider a label)
- **Exception for "== Additional resources" in assemblies:** Temporarily, the only exception to returning to block headings for procedures, etc., is for additional resources in assemblies, which should be a non-discrete "== Additional resources". The reason is that tooling will have the block label optimized for modules in Phase 1, but for assemblies in a future phase. Therefore, because includes come between the assembly title and the additional resources, it should be a genuine sub-heading and show up in the TOC (non-discrete). Prerequisites in assemblies, however, are no exception and should follow the same standard as in modules.

Links:
- [Updated templates preview](http://file.rdu.redhat.com/~sterobin/modular-docs-manual/files/)
- [Updated Mod Doc Ref Guide preview](http://file.rdu.redhat.com/~sterobin/modular-docs-manual/master.html)
