### PR TITLE
Resolves #25

### DIFF
--- a/modular-docs-manual/content/topics/module_anchor-and-file-names-concept.adoc
+++ b/modular-docs-manual/content/topics/module_anchor-and-file-names-concept.adoc
@@ -41,15 +41,20 @@ The format defined here is recommended because it is the most stable and versati
 For more information about Asciidoc anchors, see the link:http://asciidoctor.org/docs/user-manual/#anchordef[Asciidoctor User Manual].
 --
 
-File names:: Give the module file the same name as the anchor used in it (which is the same as or similar to the module heading), also separated by dashes. Add a prefix with an underscore to the file name to indicate the module type in the format `prefix_file-name`. Use `con_` for concept, `ref_` for reference, `proc_` for procedure, and `assembly_` for assembly.
+File names:: Give the module file the same name as the anchor used in it (which is the same as or similar to the module heading). Assembly and module file names should accurately and closely reflect the title of the assembly or module.
++
+[NOTE]
+====
+These guidelines for file names are _recommended_. Project teams may adapt or deviate from these guidelines if need be.
+====
 +
 .Examples
-* `con_guided-decision-tables.adoc`  (Concept module)
-* `proc_creating-guided-decision-tables.adoc`  (Procedure module for creating)
-* `proc_editing-guided-decision-tables.adoc`  (Procedure module for editing)
-* `ref_guided-decision-table-examples.adoc`  (Reference module with examples)
-* `ref_guided-decision-table-columns.adoc`  (Reference module with column types)
-* `assembly_guided-decision-tables.adoc`  (Assembly of guided decision table modules)
+* `guided-decision-tables.adoc`  (Concept module)
+* `creating-guided-decision-tables.adoc`  (Procedure module for creating)
+* `editing-guided-decision-tables.adoc`  (Procedure module for editing)
+* `guided-decision-table-examples.adoc`  (Reference module with examples)
+* `guided-decision-table-columns.adoc`  (Reference module with column types)
+* `guided-decision-tables.adoc`  (Assembly of guided decision table modules)
 
 .Additional Resources
 


### PR DESCRIPTION
Turns out the modular docs guide already had the verbiage about using the file name same as the anchors and titles. I have just deleted the bit about adding con, proc, ref and assembly from the examples etc.

I have also added that this is a recommendation, not a standard.

@tradej @sterobin @ritz303 @rkratky - PTAL.