### PR TITLE
Check for context being undefined

### DIFF
--- a/modular-docs-manual/content/topics/module_nesting-assemblies.adoc
+++ b/modular-docs-manual/content/topics/module_nesting-assemblies.adoc
@@ -20,14 +20,15 @@ To solve this problem, restore the `:context:` variable to its previous value wh
 +
 [source,asciidoc]
 ----
-:parent-context: {context}
+ifdef::context[:parent-context: {context}]
 ----
 
-. Add the following line at the end of your assemblies to restore the saved context:
+. Add the following lines to the end of your assemblies to restore the saved context, if one already existed:
 +
 [source,asciidoc]
 ----
-:context: {parent-context}
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]
 ----
 
 .Correctly Nested Assemblies

--- a/modular-docs-manual/files/TEMPLATE_ASSEMBLY_a-collection-of-modules.adoc
+++ b/modular-docs-manual/files/TEMPLATE_ASSEMBLY_a-collection-of-modules.adoc
@@ -5,7 +5,7 @@
 // Save the context of the assembly that is including this one.
 // This is necessary for including assemblies in assemblies.
 // See also the complementary step on the last line of this file.
-:parent-context: {context}
+ifdef::context[:parent-context: {context}]
 
 // Base the file name and the ID on the assembly title. For example:
 // * file name: my-assembly-a.adoc
@@ -42,4 +42,5 @@ include::modules/TEMPLATE_PROCEDURE_doing_one_procedure.adoc[leveloffset=+1]
 * Use a consistent system for file names, IDs, and titles. For tips, see _Anchor Names and File Names_ in link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
 
 // Restore the context to what it was before this assembly.
-:context: {parent-context}
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]


### PR DESCRIPTION
If context is used without being defined it generates spurious
build warnings.  This modification to the modular docs templates
allows for this situation to be checked for.