### PR TITLE
Update anchor text

### DIFF
--- a/modular-docs-manual/files/TEMPLATE_CONCEPT_concept-explanation.adoc
+++ b/modular-docs-manual/files/TEMPLATE_CONCEPT_concept-explanation.adoc
@@ -8,7 +8,7 @@
 // * Title: = My concept module A
 
 // The ID is used as an anchor for linking to the module. Avoid changing it after the module has been published to ensure existing links are not broken.
-[id='concept-explanation-{context}']
+[id='concept-explanation_{context}']
 // The `context` attribute enables module reuse. Every module's ID includes {context}, which ensures that the module has a unique ID even if it is reused multiple times in a guide.
 = Concept explanation
 //In the title of concept modules, include nouns or noun phrases that are used in the body text. This helps readers and search engines find the information quickly.


### PR DESCRIPTION
This change updates the concept template to match the procedure and reference template. They use an underscore in front of the context reference instead of a dash.