### PR TITLE
Add substitution strings for the templates to be directly usable by the newdoc script

### DIFF
--- a/modular-docs-manual/files/TEMPLATE_ASSEMBLY_a-collection-of-modules.adoc
+++ b/modular-docs-manual/files/TEMPLATE_ASSEMBLY_a-collection-of-modules.adoc
@@ -5,7 +5,7 @@
 // Retains the context of the parent assembly if this assembly is nested within another assembly.
 // For more information about nesting assemblies, see: https://redhat-documentation.github.io/modular-docs/#nesting-assemblies
 // See also the complementary step on the last line of this file.
-ifdef::context[:parent-context: {context}]
+ifdef::context[:parent-context-of-${module_id}: {context}]
 
 // Base the file name and the ID on the assembly title. For example:
 // * file name: my-assembly-a.adoc
@@ -13,11 +13,11 @@ ifdef::context[:parent-context: {context}]
 // * Title: = My assembly A
 
 // The ID is used as an anchor for linking to the module. Avoid changing it after the module has been published to ensure existing links are not broken.
-[id='a-collection-of-modules']
-// If the assembly is reused in other assemblies in a guide, include {context} in the ID: [id='a-collection-of-modules-{context}'].
-= A collection of modules
+[id='${module_id}']
+// If the assembly is reused in other assemblies in a guide, include {context} in the ID: [id='${module_id}_{context}'].
+= ${module_title}
 //If the assembly covers a task, start the title with a verb in the gerund form, such as Creating or Configuring.
-:context: assembly-keyword
+:context: ${module_id}
 // The `context` attribute enables module reuse. Every module's ID includes {context}, which ensures that the module has a unique ID even if it is reused multiple times in a guide.
 
 This paragraph is the assembly introduction. It explains what the user will accomplish by working through the modules in the assembly and sets the context for the user story the assembly is based on. Can include more than one paragraph. Consider using the information from the user story.
@@ -42,5 +42,5 @@ include::modules/TEMPLATE_PROCEDURE_doing_one_procedure.adoc[leveloffset=+1]
 * Use a consistent system for file names, IDs, and titles. For tips, see _Anchor Names and File Names_ in link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
 
 // Restore the context to what it was before this assembly.
-ifdef::parent-context[:context: {parent-context}]
-ifndef::parent-context[:!context:]
+ifdef::parent-context-of-${module_id}[:context: {parent-context-of-${module_id}}]
+ifndef::parent-context-of-${module_id}[:!context:]

--- a/modular-docs-manual/files/TEMPLATE_CONCEPT_concept-explanation.adoc
+++ b/modular-docs-manual/files/TEMPLATE_CONCEPT_concept-explanation.adoc
@@ -8,9 +8,9 @@
 // * Title: = My concept module A
 
 // The ID is used as an anchor for linking to the module. Avoid changing it after the module has been published to ensure existing links are not broken.
-[id='concept-explanation-{context}']
+[id='${module_id}_{context}']
 // The `context` attribute enables module reuse. Every module's ID includes {context}, which ensures that the module has a unique ID even if it is reused multiple times in a guide.
-= Concept explanation
+= ${module_title}
 //In the title of concept modules, include nouns or noun phrases that are used in the body text. This helps readers and search engines find the information quickly.
 //Do not start the title of concept modules with a verb. See also _Wording of headings_ in _The IBM Style Guide_.
 

--- a/modular-docs-manual/files/TEMPLATE_PROCEDURE_doing-one-procedure.adoc
+++ b/modular-docs-manual/files/TEMPLATE_PROCEDURE_doing-one-procedure.adoc
@@ -8,9 +8,9 @@
 // * Title: = Doing procedure A
 
 // The ID is used as an anchor for linking to the module. Avoid changing it after the module has been published to ensure existing links are not broken.
-[id='doing-one-procedure_{context}']
+[id='${module_id}_{context}']
 // The `context` attribute enables module reuse. Every module's ID includes {context}, which ensures that the module has a unique ID even if it is reused multiple times in a guide.
-= Doing one procedure
+= ${module_title}
 // Start the title of a procedure module with a verb, such as Creating or Create. See also _Wording of headings_ in _The IBM Style Guide_.
 
 This paragraph is the procedure module introduction: a short description of the procedure.

--- a/modular-docs-manual/files/TEMPLATE_REFERENCE_reference-material.adoc
+++ b/modular-docs-manual/files/TEMPLATE_REFERENCE_reference-material.adoc
@@ -8,9 +8,9 @@
 // * Title: = My reference A
 
 // The ID is used as an anchor for linking to the module. Avoid changing it after the module has been published to ensure existing links are not broken.
-[id='reference-material_{context}']
+[id='${module_id}_{context}']
 // The `context` attribute enables module reuse. Every module's ID includes {context}, which ensures that the module has a unique ID even if it is reused multiple times in a guide.
-= Reference material
+= ${module_title}
 //In the title of a reference module, include nouns that are used in the body text. For example, "Keyboard shortcuts for ___" or "Command options for ___." This helps readers and search engines find the information quickly.
 
 A short introductory paragraph is required for the reference module.


### PR DESCRIPTION
This PR edits template files so that they have machine-readable substitution strings in the format of the Python Template module. This makes it possible for the newdoc[1] script to download templates each time a file is generated to make sure writers always have the most up-to-date version.

Bits that have been changed:

- The module/assembly title
- The module/assembly ID
- Context-related attributes

Additionally, this PR changes the `parent-context` attribute to be assembly-specific: `parent-context-of-(assembly-ID)`. The attribute is composed automatically by newdoc when creating a new file. The reasoning is explained in [issue#71](https://github.com/redhat-documentation/modular-docs/issues/71), which is fixed with this change.

[1] https://github.com/redhat-documentation/tools/tree/master/newdoc