### PR TITLE
Update procedure module guidelines for single prereqs

### DIFF
--- a/modular-docs-manual/content/topics/module_guidelines-procedure.adoc
+++ b/modular-docs-manual/content/topics/module_guidelines-procedure.adoc
@@ -24,6 +24,8 @@ Prerequisites are conditions that must be satisfied before the user starts the p
 
 Focus on relevant prerequisites that users might not otherwise be aware of. Do not list obvious prerequisites.
 
+Use a bulleted list for prerequisites, even if you only have a single prerequisite.
+
 [discrete]
 == Procedure Body
 The procedure consists of one or more steps required to complete the procedure. Each step describes one action.


### PR DESCRIPTION
This is for Issue https://github.com/redhat-documentation/modular-docs/issues/80.

The consensus is that you should use a bulleted list for all prereqs, even if there's only one. This PR adds a short sentence to state this guidance explicitly.