### PR TITLE
standardizing -{context}

### DIFF
--- a/modular-docs-manual/content/topics/module_anchor-and-file-names-concept.adoc
+++ b/modular-docs-manual/content/topics/module_anchor-and-file-names-concept.adoc
@@ -3,7 +3,7 @@
 
 To optimize modular documentation, follow these guidelines for naming module anchors and files:
 
-Anchor names:: Provide an anchor in the format `+++[id='anchor-name-{context}']+++` for every module so that it can be identified by Asciidoctor when reused or cross-referenced. `+++{context}+++` is a variable whose value you define in the assembly. Give the anchor the same or similar name as the module heading. Separate the words in the anchor with dashes:
+Anchor names:: Provide an anchor in the format `+++[id='anchor-name-{context}']+++` for every module so that it can be identified by Asciidoctor when reused or cross-referenced. `+++{context}+++` is a variable whose value you define in the assembly. Give the anchor the same or similar name as the module heading. Separate the words in the anchor with hyphens:
 +
 --
 [source]

--- a/modular-docs-manual/content/topics/module_anchor-and-file-names-concept.adoc
+++ b/modular-docs-manual/content/topics/module_anchor-and-file-names-concept.adoc
@@ -3,12 +3,12 @@
 
 To optimize modular documentation, follow these guidelines for naming module anchors and files:
 
-Anchor names:: Provide an anchor in the format `+++[id='anchor-name_{context}']+++` for every module so that it can be identified by Asciidoctor when reused or cross-referenced. Give the anchor the same or similar name as the module heading, separated by dashes:
+Anchor names:: Provide an anchor in the format `+++[id='anchor-name-{context}']+++` for every module so that it can be identified by Asciidoctor when reused or cross-referenced. Give the anchor the same or similar name as the module heading, separated by dashes:
 +
 --
 [source]
 ----
-[id='anchor-name_{context}']
+[id='anchor-name-{context}']
 = Module Heading
 
 The first sentence of the topic.
@@ -17,7 +17,7 @@ The first sentence of the topic.
 .Example 1. Concept Module
 [source]
 ----
-[id='guided-decision-tables_{context}']
+[id='guided-decision-tables-{context}']
 = Guided Decision Tables
 
 The guided decision tables feature works similarly to ...
@@ -26,7 +26,7 @@ The guided decision tables feature works similarly to ...
 .Example 2. Procedure Module
 [source]
 ----
-[id='creating-guided-decision-tables_{context}']
+[id='creating-guided-decision-tables-{context}']
 = Creating Guided Decision Tables
 
 You can use guided decision tables to ...

--- a/modular-docs-manual/content/topics/module_anchor-and-file-names-concept.adoc
+++ b/modular-docs-manual/content/topics/module_anchor-and-file-names-concept.adoc
@@ -3,7 +3,7 @@
 
 To optimize modular documentation, follow these guidelines for naming module anchors and files:
 
-Anchor names:: Provide an anchor in the format `+++[id='anchor-name-{context}']+++` for every module so that it can be identified by Asciidoctor when reused or cross-referenced. Give the anchor the same or similar name as the module heading, separated by dashes:
+Anchor names:: Provide an anchor in the format `+++[id='anchor-name-{context}']+++` for every module so that it can be identified by Asciidoctor when reused or cross-referenced. `+++{context}+++` is a variable whose value you define in the assembly. Give the anchor the same or similar name as the module heading. Separate the words in the anchor with dashes:
 +
 --
 [source]

--- a/modular-docs-manual/content/topics/module_reusing-modules-procedure.adoc
+++ b/modular-docs-manual/content/topics/module_reusing-modules-procedure.adoc
@@ -17,7 +17,7 @@ This error is resolved by adding and defining a document variable.
 [discrete]
 .Procedure
 
-. In the module file that will be reused, add the `+++{context}+++` suffix with a dash to the anchor name in the format `[id='anchor-name-+++{context}'+++]`.
+. In the module file that will be reused, add the `+++{context}+++` suffix with a hyphen to the anchor name in the format `[id='anchor-name-+++{context}'+++]`.
 
 +
 NOTE: Although you can use any document variable that clearly indicates the variable in question, such as `+++{product}+++` or `+++{chapter}+++`, the `+++{context}+++` variable is recommended. This variable indicates more generally that the same module can be reused in the specified "context" of one section of a document or another, regardless of whether that section is product-specific or not, whether it is a whole chapter or a small assembly, or some other limitation.
@@ -36,7 +36,7 @@ NOTE: Although you can use any document variable that clearly indicates the vari
 = Module B Heading
 ----
 
- . In the assembly file or the master book file, define the `+++:context:+++` variable immediately above any included modules that are being reused, in the format `+++:context:+++ variable-name`. How you define the variable depends on whether the module is included once in multiple assemblies or is included multiple times in a single assembly. Note that the `+++:context:+++` variable definition uses dashes to separate its terms.
+ . In the assembly file or the master book file, define the `+++:context:+++` variable immediately above any included modules that are being reused, in the format `+++:context:+++ variable-name`. How you define the variable depends on whether the module is included once in multiple assemblies or is included multiple times in a single assembly. Note that the `+++:context:+++` variable definition uses hyphens to separate its terms.
 +
 Module Included Once in Multiple Assemblies:: If the reused modules are included only once in this assembly and in at least one other assembly, define an assembly-level variable such as `+++:context: assembly-name+++`. This  indicates that the reused module is appearing in the context of that assembly.
 

--- a/modular-docs-manual/content/topics/module_reusing-modules-procedure.adoc
+++ b/modular-docs-manual/content/topics/module_reusing-modules-procedure.adoc
@@ -17,7 +17,7 @@ This error is resolved by adding and defining a document variable.
 [discrete]
 .Procedure
 
-. In the module file that will be reused, add the `+++{context}+++` suffix with an underscore to the anchor name in the format `[id='anchor-name_+++{context}'+++]`.
+. In the module file that will be reused, add the `+++{context}+++` suffix with a dash to the anchor name in the format `[id='anchor-name-+++{context}'+++]`.
 
 +
 NOTE: Although you can use any document variable that clearly indicates the variable in question, such as `+++{product}+++` or `+++{chapter}+++`, the `+++{context}+++` variable is recommended. This variable indicates more generally that the same module can be reused in the specified "context" of one section of a document or another, regardless of whether that section is product-specific or not, whether it is a whole chapter or a small assembly, or some other limitation.
@@ -26,13 +26,13 @@ NOTE: Although you can use any document variable that clearly indicates the vari
 .Two Modules to Be Reused: Module A and Module B
 [source]
 ----
-[id='module-A-being-reused_{context}']
+[id='module-A-being-reused-{context}']
 = Module A Heading
 ----
 +
 [source]
 ----
-[id='module-B-being-reused_{context}']
+[id='module-B-being-reused-{context}']
 = Module B Heading
 ----
 
@@ -98,7 +98,7 @@ include::module-A-being-reused.adoc
 //
 // ...
 
-[id='module-A-being-reused_{context}']
+[id='module-A-being-reused-{context}']
 = Module A Heading
 ----
 
@@ -141,7 +141,7 @@ The module files contain the following content:
 // asset-definitions.adoc
 // business-rules.adoc
 
-[id='projects_{context}']
+[id='projects-{context}']
 = Projects
 ----
 
@@ -153,7 +153,7 @@ The module files contain the following content:
 // asset-definitions.adoc
 // business-rules.adoc
 
-[id='creating-assets_{context}']
+[id='creating-assets-{context}']
 = Creating Assets
 ----
 
@@ -219,7 +219,7 @@ The module file contains the following content:
 .projects.adoc
 [source]
 ----
-[id='projects_{context}']
+[id='projects-{context}']
 = Projects
 ----
 

--- a/modular-docs-manual/content/topics/module_reusing-modules-procedure.adoc
+++ b/modular-docs-manual/content/topics/module_reusing-modules-procedure.adoc
@@ -36,7 +36,7 @@ NOTE: Although you can use any document variable that clearly indicates the vari
 = Module B Heading
 ----
 
- . In the assembly file or the master book file, define the `+++:context:+++` variable, separated by dashes, immediately above any included modules that are being reused, in the format `+++:context:+++ variable-name`. How you define the variable depends on whether the module is included once in multiple assemblies, or is included multiple times in a single assembly.
+ . In the assembly file or the master book file, define the `+++:context:+++` variable immediately above any included modules that are being reused, in the format `+++:context:+++ variable-name`. How you define the variable depends on whether the module is included once in multiple assemblies or is included multiple times in a single assembly. Note that the `+++:context:+++` variable definition uses dashes to separate its terms.
 +
 Module Included Once in Multiple Assemblies:: If the reused modules are included only once in this assembly and in at least one other assembly, define an assembly-level variable such as `+++:context: assembly-name+++`. This  indicates that the reused module is appearing in the context of that assembly.
 

--- a/modular-docs-manual/content/topics/using_text_snippets_or_text_fragments.adoc
+++ b/modular-docs-manual/content/topics/using_text_snippets_or_text_fragments.adoc
@@ -4,12 +4,12 @@
 
 // Base the file name and the ID on the module title. For example:
 // * file name: my-concept-module-a.adoc
-// * ID: [id='my-concept-module-a']
+// * ID: [id='my-concept-module-a-{context}']
 // * Title: = My concept module A
 
 // The ID is used as an anchor for linking to the module. Avoid changing it after the module has been published to ensure existing links are not broken.
-[id='using_text_snippets_or_text_fragments']
-// The `context` attribute enables module reuse. Every module's ID includes {context}, which ensures that the module has a unique ID even if it is reused multiple times in a guide.
+[id='using_text_snippets_or_text_fragments-{context}']
+// The `context` attribute enables module reuse. Every module's ID includes a variable that sets the context, such as {context}, which ensures that the module has a unique ID even if it is reused multiple times in a guide.
 = Text Snippets or Text Fragments (Pseudo-modules)
 //In the title of concept modules, include nouns or noun phrases that are used in the body text. This helps readers and search engines find the information quickly.
 //Do not start the title of concept modules with a verb. See also _Wording of headings_ in _The IBM Style Guide_.

--- a/modular-docs-manual/files/TEMPLATE_CONCEPT_concept-explanation.adoc
+++ b/modular-docs-manual/files/TEMPLATE_CONCEPT_concept-explanation.adoc
@@ -4,7 +4,7 @@
 
 // Base the file name and the ID on the module title. For example:
 // * file name: my-concept-module-a.adoc
-// * ID: [id='my-concept-module-a']
+// * ID: [id='my-concept-module-a-{context}']
 // * Title: = My concept module A
 
 // The ID is used as an anchor for linking to the module. Avoid changing it after the module has been published to ensure existing links are not broken.


### PR DESCRIPTION
Fixes #58 

All of the sample files now use `-{context}` in the anchor IDs, so we should update the rest of the topics.

I've updated this PR to include fixes for the remaining issues in #58.