### PR TITLE
Fixed copy/paste error, one subject/verb agreement error.

### DIFF
--- a/modular-docs-manual/files/TEMPLATE_PROCEDURE_doing-one-procedure.adoc
+++ b/modular-docs-manual/files/TEMPLATE_PROCEDURE_doing-one-procedure.adoc
@@ -17,9 +17,9 @@ This paragraph is the procedure module introduction: a short description of the 
 
 .Prerequisites
 
-* A bulleted list of conditions that must be satisfied before the user starts following this assembly.
-* You can also link to other modules or assemblies the user must follow before starting this assembly.
-* Delete the section title and bullets if the assembly has no prerequisites.
+* A bulleted list of conditions that must be satisfied before the user starts following this module.
+* You can also link to other modules or assemblies the user must follow before starting this module.
+* Delete the section title and bullets if the module has no prerequisites.
 
 .Procedure
 

--- a/modular-docs-manual/files/TEMPLATE_REFERENCE_reference-material.adoc
+++ b/modular-docs-manual/files/TEMPLATE_REFERENCE_reference-material.adoc
@@ -16,7 +16,7 @@
 A short introductory paragraph is required for the reference module.
 It will provide an overview of the module.
 
-A reference module provide data that users might want to look up, but do not need to remember.
+A reference module provides data that users might want to look up, but do not need to remember.
 It has a very strict structure, often in the form of a list or a table.
 A well-organized reference module enables users to scan it quickly to find the details they want.
 AsciiDoc markup to consider for reference data:


### PR DESCRIPTION
The "prerequisites" section in the procedure module template looks like it was copy/pasted from the assembly template, as it referred to prerequisites for the assembly (not the module).