### PR TITLE
Resolves Issues 109, 111, and 115

### DIFF
--- a/modular-docs-manual/content/topics/introduction.adoc
+++ b/modular-docs-manual/content/topics/introduction.adoc
@@ -1,8 +1,4 @@
 [id="introduction_{context}"]
 = Introduction to Modular Documentation
 
-This guide provides instructions on how to author modularly structured user stories. It defines terminology, describes components that form modular documentation, and provides instructions on how to use the provided modularization templates to create user stories. Most of the information included in this guide is generic. However, some instructions are required for documents that will be published on the Pantheon version 2 (V2) documentation management system. This requirement is noted where applicable.
-
-Pantheon V2 is an open-source modular documentation management system being developed by Red Hat. The engineering team is building the ability to import modular content written in AsciiDoc from one or more Git repositories, assign metadata to it to enhance search-engine optimization, and publish that content to one or more targets.
-
-The Pantheon community is still new but growing, and through ongoing development Red Hat aims to provide a solution that not only powers its own product documentation teams, but also offers greater flexibility to open source communities to create modular content that addresses individual use cases and can be drawn and combined from multiple sources.
+This manual provides instructions on how to author modularly structured documentation based on user stories. The manual defines used terminology, describes components that form modular documentation, and instructs writers on how to use provided templates to turn user stories into modular documentation.

--- a/modular-docs-manual/content/topics/introduction.adoc
+++ b/modular-docs-manual/content/topics/introduction.adoc
@@ -1,4 +1,8 @@
-[id="introduction"]
-= Introduction
+[id="introduction_{context}"]
+= Introduction to Modular Documentation
 
-This manual provides instructions on how to author modularly structured documentation based on user stories. The manual defines used terminology, describes components that form modular documentation, and instructs writers on how to use provided templates to turn user stories into modular documentation.
+This guide provides instructions on how to author modularly structured user stories. It defines terminology, describes components that form modular documentation, and provides instructions on how to use the provided modularization templates to create user stories. Most of the information included in this guide is generic. However, some instructions are required for documents that will be published on the Pantheon version 2 (V2) documentation management system. This requirement is noted where applicable.
+
+Pantheon V2 is an open-source modular documentation management system being developed by Red Hat. The engineering team is building the ability to import modular content written in AsciiDoc from one or more Git repositories, assign metadata to it to enhance search-engine optimization, and publish that content to one or more targets.
+
+The Pantheon community is still new but growing, and through ongoing development Red Hat aims to provide a solution that not only powers its own product documentation teams, but also offers greater flexibility to open source communities to create modular content that addresses individual use cases and can be drawn and combined from multiple sources.

--- a/modular-docs-manual/content/topics/module_anchor-and-file-names-concept.adoc
+++ b/modular-docs-manual/content/topics/module_anchor-and-file-names-concept.adoc
@@ -27,7 +27,7 @@ Create assembly and module file names that accurately and closely reflect the ti
 Do not include special characters in file names. Ensure that all members of your team use the same file naming conventions.
 ====
 
-These file naming guidelines are optional but highly recommended. However, if your team does not include the module prefixes in file names followed by either a hyphen (-) or an underscore (_), you must include one of the following variables in each concept, procedure, and reference module:
+These file naming guidelines are optional but highly recommended. However, if your team does not include the module prefixes in file names followed by either a hyphen (-) or an underscore (_), include one of the following variables in each concept, procedure, and reference module:
 
 [source]
 ----
@@ -35,8 +35,6 @@ These file naming guidelines are optional but highly recommended. However, if yo
 :system-module-type: PROCEDURE
 :system-module-type: REFERENCE
 ----
-
-NOTE: This is a requirement if you will publish on Pantheon V2. For more information, see xref:introduction_{context}[].
 
 .Anchors
 At the top of every module, provide an anchor in the format `+++[id="filename_{context}"]+++` where `filename` is the exact name of the file, without the file extension (`.adoc`). Module anchors are necessary so that Asciidoctor can identify the module when the module is reused or cross-referenced. The  `context` variable is defined in each assembly module, for example `:context: my-context-value`. When you build an assembly, the value of the `context` variable replaces `{context}` in each module anchor ID and appears in generated URL.

--- a/modular-docs-manual/content/topics/module_anchor-and-file-names-concept.adoc
+++ b/modular-docs-manual/content/topics/module_anchor-and-file-names-concept.adoc
@@ -62,7 +62,7 @@ The guided decision tables feature works similarly to ...
 .Example 2. Procedure Module
 [source]
 ----
-[id="pro-creating-guided-decision-tables_{context}"]
+[id="proc-creating-guided-decision-tables_{context}"]
 = Creating Guided Decision Tables
 
 You can use guided decision tables to ...

--- a/modular-docs-manual/content/topics/module_anchor-and-file-names-concept.adoc
+++ b/modular-docs-manual/content/topics/module_anchor-and-file-names-concept.adoc
@@ -4,7 +4,7 @@
 To optimize modular documentation, follow these guidelines for naming files and creating anchors:
 
 .File names
-Assembly and module file names should accurately and closely reflect the title of the assembly or module. File names should have the format `prefix-filename.adoc` or `prefix_filename.adoc` where `prefix` is one of the following module prefixes:
+Create assembly and module file names that accurately and closely reflect the title of the assembly or module. Create file names with the format `prefix-filename.adoc` or `prefix_filename.adoc` where `prefix` is one of the following module prefixes:
 
 * `con`: Concept module prefix
 * `proc`: Procedure module prefix
@@ -13,11 +13,13 @@ Assembly and module file names should accurately and closely reflect the title o
 
 .Examples
 * `con-guided-decision-tables.adoc`  (Concept module)
+* `con_guided-decision-tables.adoc`  (Concept module)
 * `proc-creating-guided-decision-tables.adoc`  (Procedure module for creating)
-* `proc-editing-guided-decision-tables.adoc`  (Procedure module for editing)
+* `proc_creating-guided-decision-tables.adoc`  (Procedure module for creating)
 * `ref-guided-decision-table-examples.adoc`  (Reference module with examples)
-* `ref-guided-decision-table-columns.adoc`  (Reference module with column types)
+* `ref_guided-decision-table-examples.adoc`  (Reference module with examples)
 * `assembly-designing-guided-decision-tables.adoc`  (Assembly of guided decision table modules)
+* `assembly_designing-guided-decision-tables.adoc`  (Assembly of guided decision table modules)
 
 
 [NOTE]
@@ -26,8 +28,6 @@ Do not include special characters in file names. Ensure that all members of your
 ====
 
 These file naming guidelines are optional but highly recommended. However, if your team does not include the module prefixes in file names followed by either a hyphen (-) or an underscore (_), you must include one of the following variables in each concept, procedure, and reference module:
-
-NOTE: This is a Pantheon 2 requirement.
 
 [source]
 ----
@@ -39,8 +39,8 @@ NOTE: This is a Pantheon 2 requirement.
 
 
 .Anchors
-At the top of every module, provide an anchor in the format `+++[id="filename_{context}"]+++` where `filename` is the exact name of the file, without the file extension (`.adoc`). Module anchors are necessary so that the module can be identified by Asciidoctor when reused or cross-referenced. The `{context}` variable is intentionally not defined in the module anchor ID. You define a context value in each assembly, in the format `:context: my-context-value`. This enables the context variable in each module to be populated according to the relevant assembly.
---
+At the top of every module, provide an anchor in the format `+++[id="filename_{context}"]+++` where `filename` is the exact name of the file, without the file extension (`.adoc`). Module anchors are necessary so that Asciidoctor can identify the module when the module is reused or cross-referenced. The  `context` variable is defined in each assembly module, for example `:context: my-context-value`. When you build an assembly, the value of the `context` variable replaces `{context}` in each module anchor ID and appears in generated URL.
+
 [source]
 ----
 [id="filename_{context}"]
@@ -53,16 +53,34 @@ The first sentence of the topic.
 [source]
 ----
 [id="con-guided-decision-tables_{context}"]
-
 = Guided Decision Tables
 
 The guided decision tables feature works similarly to ...
 ----
 
-.Example 2. Procedure Module
+.Example 2. Concept Module
+[source]
+----
+[id="con_guided-decision-tables_{context}"]
+= Guided Decision Tables
+
+The guided decision tables feature works similarly to ...
+----
+
+
+.Example 3. Procedure Module
 [source]
 ----
 [id="proc-creating-guided-decision-tables_{context}"]
+= Creating Guided Decision Tables
+
+You can use guided decision tables to ...
+----
+
+.Example 4. Procedure Module
+[source]
+----
+[id="proc_creating-guided-decision-tables_{context}"]
 = Creating Guided Decision Tables
 
 You can use guided decision tables to ...
@@ -74,7 +92,7 @@ You can use guided decision tables to ...
 The format defined here is recommended because it is the most stable and versatile of anchor formats, and supports variables that enable topics to be reused and cross-referenced properly. For details, see xref:reusing-modules[]. Other anchor formats include `+++[[anchor-name]]+++` and `+++[#anchor-name]+++`, but these formats either do not support variables for content reuse or do not support certain character types, such as periods. These limitations cause errors at build time.
 ====
 
---
+
 
 .Additional Resources
 

--- a/modular-docs-manual/content/topics/module_anchor-and-file-names-concept.adoc
+++ b/modular-docs-manual/content/topics/module_anchor-and-file-names-concept.adoc
@@ -36,7 +36,7 @@ These file naming guidelines are optional but highly recommended. However, if yo
 :system-module-type: REFERENCE
 ----
 
-
+NOTE: This is a requirement if you will publish on Pantheon V2. For more information, see xref:introduction_{context}[].
 
 .Anchors
 At the top of every module, provide an anchor in the format `+++[id="filename_{context}"]+++` where `filename` is the exact name of the file, without the file extension (`.adoc`). Module anchors are necessary so that Asciidoctor can identify the module when the module is reused or cross-referenced. The  `context` variable is defined in each assembly module, for example `:context: my-context-value`. When you build an assembly, the value of the `context` variable replaces `{context}` in each module anchor ID and appears in generated URL.

--- a/modular-docs-manual/content/topics/module_anchor-and-file-names-concept.adoc
+++ b/modular-docs-manual/content/topics/module_anchor-and-file-names-concept.adoc
@@ -1,14 +1,49 @@
-[id="anchor-and-file-names"]
-= Anchor Names and File Names
+[id="module_anchor-and-file-names-concept"]
+= File Names and Anchors
 
-To optimize modular documentation, follow these guidelines for naming module anchors and files:
+To optimize modular documentation, follow these guidelines for naming files and creating anchors:
 
-Anchor names:: Provide an anchor in the format `+++[id="anchor-name_{context}"]+++` for every module so that it can be identified by Asciidoctor when reused or cross-referenced. `+++{context}+++` is a variable whose value you define in the assembly. Give the anchor the same or similar name as the module heading. Separate the words in the anchor with hyphens and use an underscore to separate the `+++{context}+++` part:
-+
+.File names
+Assembly and module file names should accurately and closely reflect the title of the assembly or module. File names should have the format `prefix-filename.adoc` or `prefix_filename.adoc` where `prefix` is one of the following module prefixes:
+
+* `con`: Concept module prefix
+* `proc`: Procedure module prefix
+* `ref`: Reference module prefix
+* `assembly`: Assembly module prefix
+
+.Examples
+* `con-guided-decision-tables.adoc`  (Concept module)
+* `proc-creating-guided-decision-tables.adoc`  (Procedure module for creating)
+* `proc-editing-guided-decision-tables.adoc`  (Procedure module for editing)
+* `ref-guided-decision-table-examples.adoc`  (Reference module with examples)
+* `ref-guided-decision-table-columns.adoc`  (Reference module with column types)
+* `assembly-designing-guided-decision-tables.adoc`  (Assembly of guided decision table modules)
+
+
+[NOTE]
+====
+Do not include special characters in file names. Ensure that all members of your team use the same file naming conventions.
+====
+
+These file naming guidelines are optional but highly recommended. However, if your team does not include the module prefixes in file names followed by either a hyphen (-) or an underscore (_), you must include one of the following variables in each concept, procedure, and reference module:
+
+NOTE: This is a Pantheon 2 requirement.
+
+[source]
+----
+:system-module-type: CONCEPT
+:system-module-type: PROCEDURE
+:system-module-type: REFERENCE
+----
+
+
+
+.Anchors
+At the top of every module, provide an anchor in the format `+++[id="filename_{context}"]+++` where `filename` is the exact name of the file, without the file extension (`.adoc`). Module anchors are necessary so that the module can be identified by Asciidoctor when reused or cross-referenced. The `{context}` variable is intentionally not defined in the module anchor ID. You define a context value in each assembly, in the format `:context: my-context-value`. This enables the context variable in each module to be populated according to the relevant assembly.
 --
 [source]
 ----
-[id="anchor-name_{context}"]
+[id="filename_{context}"]
 = Module Heading
 
 The first sentence of the topic.
@@ -17,7 +52,8 @@ The first sentence of the topic.
 .Example 1. Concept Module
 [source]
 ----
-[id="guided-decision-tables_{context}"]
+[id="con-guided-decision-tables_{context}"]
+
 = Guided Decision Tables
 
 The guided decision tables feature works similarly to ...
@@ -26,7 +62,7 @@ The guided decision tables feature works similarly to ...
 .Example 2. Procedure Module
 [source]
 ----
-[id="creating-guided-decision-tables_{context}"]
+[id="pro-creating-guided-decision-tables_{context}"]
 = Creating Guided Decision Tables
 
 You can use guided decision tables to ...
@@ -38,26 +74,8 @@ You can use guided decision tables to ...
 The format defined here is recommended because it is the most stable and versatile of anchor formats, and supports variables that enable topics to be reused and cross-referenced properly. For details, see xref:reusing-modules[]. Other anchor formats include `+++[[anchor-name]]+++` and `+++[#anchor-name]+++`, but these formats either do not support variables for content reuse or do not support certain character types, such as periods. These limitations cause errors at build time.
 ====
 
-NOTE: The underscore is recommended as the separator for `+++{context}+++`, because this facilitates tooling to distinguish the context part from the base anchor ID.
-
-For more information about Asciidoc anchors, see the link:http://asciidoctor.org/docs/user-manual/#anchordef[Asciidoctor User Manual].
 --
-
-File names:: Give the module file the same name as the anchor used in it (which is the same as or similar to the module heading). Assembly and module file names should accurately and closely reflect the title of the assembly or module.
-+
-[NOTE]
-====
-Ensure that all members of your team use the same file naming conventions.
-====
-+
-.Examples
-* `guided-decision-tables.adoc`  (Concept module)
-* `creating-guided-decision-tables.adoc`  (Procedure module for creating)
-* `editing-guided-decision-tables.adoc`  (Procedure module for editing)
-* `guided-decision-table-examples.adoc`  (Reference module with examples)
-* `guided-decision-table-columns.adoc`  (Reference module with column types)
-* `designing-guided-decision-tables.adoc`  (Assembly of guided decision table modules)
 
 .Additional Resources
 
-* The link:http://asciidoctor.org/docs/user-manual/#anchordef[Asciidoctor User Manual]
+* link:https://asciidoctor.org/docs/user-manual/[Asciidoctor User Manual]

--- a/modular-docs-manual/content/topics/using_text_snippets_or_text_fragments.adoc
+++ b/modular-docs-manual/content/topics/using_text_snippets_or_text_fragments.adoc
@@ -1,18 +1,8 @@
-// Module included in the following assemblies:
-//
-// <List assemblies here, each on a new line>
 
-// Base the file name and the ID on the module title. For example:
-// * file name: my-concept-module-a.adoc
-// * ID: [id="my-concept-module-a_{context}"]
-// * Title: = My concept module A
+[id='using_text_snippets_or_text_fragments']
 
-// The ID is used as an anchor for linking to the module. Avoid changing it after the module has been published to ensure existing links are not broken.
-[id="using_text_snippets_or_text_fragments_{context}"]
-// The `context` attribute enables module reuse. Every module's ID includes a variable that sets the context, such as {context}, which ensures that the module has a unique ID even if it is reused multiple times in a guide.
 = Text Snippets or Text Fragments (Pseudo-modules)
-//In the title of concept modules, include nouns or noun phrases that are used in the body text. This helps readers and search engines find the information quickly.
-//Do not start the title of concept modules with a verb. See also _Wording of headings_ in _The IBM Style Guide_.
+
 
 [NOTE]
 The following standard is recommended when the documentation is being maintained without a Content Management System (CMS) capable of managing complex interrelations between modules.
@@ -23,8 +13,3 @@ Snippet (fragment) file use should be limited to:
 
 * Standardized admonitions (such as 'Technology preview' and 'Beta' text).
 * Where there is an existing standard between the upstream and downstream communities.
-
-
-//.Additional resources
-
-//* A bulleted list of links to other material closely related to the contents of the concept module.

--- a/modular-docs-manual/content/topics/using_text_snippets_or_text_fragments.adoc
+++ b/modular-docs-manual/content/topics/using_text_snippets_or_text_fragments.adoc
@@ -1,8 +1,18 @@
+// Module included in the following assemblies:
+//
+// <List assemblies here, each on a new line>
 
-[id='using_text_snippets_or_text_fragments']
+// Base the file name and the ID on the module title. For example:
+// * file name: my-concept-module-a.adoc
+// * ID: [id="my-concept-module-a_{context}"]
+// * Title: = My concept module A
 
+// The ID is used as an anchor for linking to the module. Avoid changing it after the module has been published to ensure existing links are not broken.
+[id="using_text_snippets_or_text_fragments_{context}"]
+// The `context` attribute enables module reuse. Every module's ID includes a variable that sets the context, such as {context}, which ensures that the module has a unique ID even if it is reused multiple times in a guide.
 = Text Snippets or Text Fragments (Pseudo-modules)
-
+//In the title of concept modules, include nouns or noun phrases that are used in the body text. This helps readers and search engines find the information quickly.
+//Do not start the title of concept modules with a verb. See also _Wording of headings_ in _The IBM Style Guide_.
 
 [NOTE]
 The following standard is recommended when the documentation is being maintained without a Content Management System (CMS) capable of managing complex interrelations between modules.
@@ -13,3 +23,8 @@ Snippet (fragment) file use should be limited to:
 
 * Standardized admonitions (such as 'Technology preview' and 'Beta' text).
 * Where there is an existing standard between the upstream and downstream communities.
+
+
+//.Additional resources
+
+//* A bulleted list of links to other material closely related to the contents of the concept module.


### PR DESCRIPTION
[Rendered HTML](http://file.ork.redhat.com/~emmurphy/file-names-and-anchors#module_anchor-and-file-names-concept)

[Modular Documentation Review Board Notes](https://docs.google.com/document/d/10uGTmEPeFgYvOZQZnfo-VGrRltRSbAwU70eppULahas/edit#heading=h.kat2ctqr49lg)

This update reflects recent decisions by the Modular Documentation Review Board:
File names must be prefixed with proc-, con-, or ref-, or proc_, con_, or ref_, or each module must include a module type variable.
While not a requirement of Pantheon, it is good practice to include the prefix assembly- or assembly_ with assembly module files.

After consultation with the Pantheon engineering team, they agreed that we can change :pantheon-module-type: to :system-module-type: to make it more generic.

Anchor names should match files names without the .adoc extension, and with the addition of _{context}.

Please review these changes and post your comments or approval.