### PR TITLE
Recommendation to use second level heading syntax for assembly-level prerequisites

### DIFF
--- a/modular-docs-manual/content/topics/module_guidelines-assembly.adoc
+++ b/modular-docs-manual/content/topics/module_guidelines-assembly.adoc
@@ -16,7 +16,9 @@ Consider rewording the user story to write the assembly introduction, for exampl
 [discrete]
 == Assembly Prerequisites
 
-Prerequisites are conditions that must be satisfied before the user can start following the assembly.
+Prerequisites are conditions that must be satisfied before the user can start following the assembly and are applicable to all the modules in the assembly.
+
+Use the second level heading syntax for the Prerequisites section in the assembly so that it is displayed in the table of contents and is consistent with the Additional resources or Next steps sections in the assembly.
 
 // [bhardest] - We have a lot of xref-ing in these guidelines. A better approach might be to create a "snippets" .adoc file with snippets of common content (for example, the content about writing prerequisites, which applies to multiple sections). Then we can just include the relevant content from the snippets file wherever it's needed.
 // [asteflova] - Let's do this after we finish reviewing the guidelines for procedures and assemblies.

--- a/modular-docs-manual/files/TEMPLATE_ASSEMBLY_a-collection-of-modules.adoc
+++ b/modular-docs-manual/files/TEMPLATE_ASSEMBLY_a-collection-of-modules.adoc
@@ -22,7 +22,7 @@ ifdef::context[:parent-context: {context}]
 
 This paragraph is the assembly introduction. It explains what the user will accomplish by working through the modules in the assembly and sets the context for the user story the assembly is based on. Can include more than one paragraph. Consider using the information from the user story.
 
-.Prerequisites
+== Prerequisites
 
 * A bulleted list of conditions that must be satisfied before the user starts following this assembly.
 * You can also link to other modules or assemblies the user must follow before starting this assembly.


### PR DESCRIPTION
This issue fixes #124 as per discussions with the team and as per comments on the issue.