### PR TITLE
On Hold: issue-135 Change format of Additional Resources/Next Steps to bulleted links only in the templates

### DIFF
--- a/modular-docs-manual/files/TEMPLATE_ASSEMBLY_a-collection-of-modules.adoc
+++ b/modular-docs-manual/files/TEMPLATE_ASSEMBLY_a-collection-of-modules.adoc
@@ -36,10 +36,10 @@ include::modules/TEMPLATE_CONCEPT_explaining_a_concept.adoc[leveloffset=+1]
 include::modules/TEMPLATE_PROCEDURE_doing_one_procedure.adoc[leveloffset=+1]
 
 == Additional resources (or Next steps)
+// A bulleted list of links to other material closely related to the contents of the assembly, including xref links to other assemblies in your collection.
 
-* A bulleted list of links to other material closely related to the contents of the assembly, including xref links to other assemblies in your collection.
-* For more details on writing assemblies, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
-* Use a consistent system for file names, IDs, and titles. For tips, see _Anchor Names and File Names_ in link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
+* link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide]
+* link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide]
 
 // Restore the context to what it was before this assembly.
 ifdef::parent-context[:context: {parent-context}]

--- a/modular-docs-manual/files/TEMPLATE_CONCEPT_concept-explanation.adoc
+++ b/modular-docs-manual/files/TEMPLATE_CONCEPT_concept-explanation.adoc
@@ -25,7 +25,5 @@ The contents of a concept module give the user descriptions and explanations nee
 
 .Additional resources
 
-* A bulleted list of links to other material closely related to the contents of the concept module.
-* Currently, modules cannot include xrefs, so you cannot include links to other content in your collection. If you need to link to another assembly, add the xref to the assembly that includes this module.
-* For more details on writing concept modules, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
-* Use a consistent system for file names, IDs, and titles. For tips, see _Anchor Names and File Names_ in link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
+* link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide]
+* link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide]

--- a/modular-docs-manual/files/TEMPLATE_PROCEDURE_doing-one-procedure.adoc
+++ b/modular-docs-manual/files/TEMPLATE_PROCEDURE_doing-one-procedure.adoc
@@ -34,7 +34,5 @@ This paragraph is the procedure module introduction: a short description of the 
 
 .Additional resources
 
-* A bulleted list of links to other material closely related to the contents of the procedure module.
-* Currently, modules cannot include xrefs, so you cannot include links to other content in your collection. If you need to link to another assembly, add the xref to the assembly that includes this module.
-* For more details on writing procedure modules, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
-* Use a consistent system for file names, IDs, and titles. For tips, see _Anchor Names and File Names_ in link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
+* link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide]
+* link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide]


### PR DESCRIPTION
[Issue 135](https://github.com/redhat-documentation/modular-docs/issues/135)