### PR TITLE
Add code owners for PR review purposes.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,6 @@
+# Set the FFC Review Board team to own the entire repo
+# (so that we can request (and require) PR reviews before merging).
+* @redhat-documentation/fcc-review-board
+
+# Additional (more granular) ownership rules:
+


### PR DESCRIPTION
This PR adds a `CODEOWNERS` file that specifies the [FCC Review Board]() team members as the code owners of the repo. 

Following a merge, a new 'branch protection rule' should be introduced to require PR reviews by code owners.

Fixes #141.