### PR TITLE
Add additional resources to reference template

### DIFF
--- a/modular-docs-manual/files/TEMPLATE_REFERENCE_reference-material.adoc
+++ b/modular-docs-manual/files/TEMPLATE_REFERENCE_reference-material.adoc
@@ -50,5 +50,5 @@ Optional. Delete if not used.
 ////
 * A bulleted list of links to other material closely related to the contents of the concept module.
 * Currently, modules cannot include xrefs, so you cannot include links to other content in your collection. If you need to link to another assembly, add the xref to the assembly that includes this module.
-* For more details on writing concept modules, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
+* For more details on writing reference modules, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
 * Use a consistent system for file names, IDs, and titles. For tips, see _Anchor Names and File Names_ in link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].

--- a/modular-docs-manual/files/TEMPLATE_REFERENCE_reference-material.adoc
+++ b/modular-docs-manual/files/TEMPLATE_REFERENCE_reference-material.adoc
@@ -13,32 +13,12 @@ The ID is an anchor that links to the module. Avoid changing it after the module
 
 [id="ref-reference-material_{context}"]
 ////
-The `context` attribute enables module reuse. Every module ID includes {context}, which ensures that the module has a unique ID even if it is reused multiple times in a guide
+[role="_additional-resources"]
+.Additional resources
 ////
-= Reference material
+Optional. Delete if not used.
 ////
-In the title of a reference module, include nouns that are used in the body text. For example, "Keyboard shortcuts for ___" or "Command options for ___." This helps readers and search engines find the information quickly.
-////
-
-[role="_abstract"]
-Write a short introductory paragraph that provides an overview of the module. The text that immediately follows the `[role="_abstract"]` tag is used for search metadata. A reference module provides data that users might want to look up, but do not need to remember.
-It has a very strict structure, often in the form of a list or a table.
-A well-organized reference module enables users to scan it quickly to find the details they want.
-AsciiDoc markup to consider for reference data:
-
-.Unordered list
-* For more details on writing reference modules, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
-* Use a consistent system for file names, IDs, and titles.
-For tips, see _Anchor Names and File Names_ in link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
-
-.Labeled list
-Term 1:: Definition
-Term 2:: Definition
-
-.Table
-[options="header"]
-|====
-|Column 1|Column 2|Column 3
-|Row 1, column 1|Row 1, column 2|Row 1, column 3
-|Row 2, column 1|Row 2, column 2|Row 2, column 3
-|====
+* A bulleted list of links to other material closely related to the contents of the concept module.
+* Currently, modules cannot include xrefs, so you cannot include links to other content in your collection. If you need to link to another assembly, add the xref to the assembly that includes this module.
+* For more details on writing concept modules, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
+* Use a consistent system for file names, IDs, and titles. For tips, see _Anchor Names and File Names_ in link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].

--- a/modular-docs-manual/files/TEMPLATE_REFERENCE_reference-material.adoc
+++ b/modular-docs-manual/files/TEMPLATE_REFERENCE_reference-material.adoc
@@ -13,6 +13,36 @@ The ID is an anchor that links to the module. Avoid changing it after the module
 
 [id="ref-reference-material_{context}"]
 ////
+The `context` attribute enables module reuse. Every module ID includes {context}, which ensures that the module has a unique ID even if it is reused multiple times in a guide
+////
+= Reference material
+////
+In the title of a reference module, include nouns that are used in the body text. For example, "Keyboard shortcuts for ___" or "Command options for ___." This helps readers and search engines find the information quickly.
+////
+
+[role="_abstract"]
+Write a short introductory paragraph that provides an overview of the module. The text that immediately follows the `[role="_abstract"]` tag is used for search metadata. A reference module provides data that users might want to look up, but do not need to remember.
+It has a very strict structure, often in the form of a list or a table.
+A well-organized reference module enables users to scan it quickly to find the details they want.
+AsciiDoc markup to consider for reference data:
+
+.Unordered list
+* For more details on writing reference modules, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
+* Use a consistent system for file names, IDs, and titles.
+For tips, see _Anchor Names and File Names_ in link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
+
+.Labeled list
+Term 1:: Definition
+Term 2:: Definition
+
+.Table
+[options="header"]
+|====
+|Column 1|Column 2|Column 3
+|Row 1, column 1|Row 1, column 2|Row 1, column 3
+|Row 2, column 1|Row 2, column 2|Row 2, column 3
+|====
+
 [role="_additional-resources"]
 .Additional resources
 ////


### PR DESCRIPTION
The reference template does not have the optional Additional Resources section. This appears to be an oversight.