### PR TITLE
module-type-update changed :system-module-type:  to :_module-type:

### DIFF
--- a/modular-docs-manual/content/topics/module_anchor-and-file-names-concept.adoc
+++ b/modular-docs-manual/content/topics/module_anchor-and-file-names-concept.adoc
@@ -31,9 +31,9 @@ These file naming guidelines are optional but highly recommended. However, if yo
 
 [source]
 ----
-:system-module-type: CONCEPT
-:system-module-type: PROCEDURE
-:system-module-type: REFERENCE
+:_module-type: CONCEPT
+:_module-type: PROCEDURE
+:_module-type: REFERENCE
 ----
 
 .Anchors


### PR DESCRIPTION
This is at the request of the Pantheon 2 team to be consistent with the [role="_abstract"] and [role="_additional-resources"] tags.

 Format for identifying module types if you do not include the module type in the the file name:
:_module-type: CONCEPT
:_module-type: PROCEDURE
:_module-type: REFERENCE




