### PR TITLE
Adding _module-type metadata flag to template files

### DIFF
--- a/modular-docs-manual/files/TEMPLATE_ASSEMBLY_a-collection-of-modules.adoc
+++ b/modular-docs-manual/files/TEMPLATE_ASSEMBLY_a-collection-of-modules.adoc
@@ -7,6 +7,13 @@ See also the complementary step on the last line of this file.
 ifdef::context[:parent-context: {context}]
 
 ////
+Pantheon v2 extracts some information from variables defined in the document content. These variables must be defined at the header level (not at the body level); otherwise, Pantheon v2 cannot extract them.
+
+As of this writing, the only such variable is `:_module-type:`, but future development may introduce other such variables as well.
+////
+:_module-type: ASSEMBLY
+
+////
  Base the file name and the ID on the assembly title. For example:
 * file name: assembly-my-user-story.adoc
 * ID: [id="assembly-my-user-story_{context}"]

--- a/modular-docs-manual/files/TEMPLATE_CONCEPT_concept-explanation.adoc
+++ b/modular-docs-manual/files/TEMPLATE_CONCEPT_concept-explanation.adoc
@@ -1,4 +1,11 @@
 ////
+Pantheon v2 extracts some information from variables defined in the document content. These variables must be defined at the header level (not at the body level); otherwise, Pantheon v2 cannot extract them.
+
+As of this writing, the only such variable is `:_module-type:`, but future development may introduce other such variables as well.
+////
+:_module-type: CONCEPT
+
+////
 Base the file name and the ID on the module title. For example:
 * file name: con-my-concept-module-a.adoc
 * ID: [id="con-my-concept-module-a_{context}"]

--- a/modular-docs-manual/files/TEMPLATE_PROCEDURE_doing-one-procedure.adoc
+++ b/modular-docs-manual/files/TEMPLATE_PROCEDURE_doing-one-procedure.adoc
@@ -1,4 +1,11 @@
 ////
+Pantheon v2 extracts some information from variables defined in the document content. These variables must be defined at the header level (not at the body level); otherwise, Pantheon v2 cannot extract them.
+
+As of this writing, the only such variable is `:_module-type:`, but future development may introduce other such variables as well.
+////
+:_module-type: PROCEDURE
+
+////
 Base the file name and the ID on the module title. For example:
 * file name: proc-doing-procedure-a.adoc
 * ID: [id="doing-procedure-a_{context}"]

--- a/modular-docs-manual/files/TEMPLATE_REFERENCE_reference-material.adoc
+++ b/modular-docs-manual/files/TEMPLATE_REFERENCE_reference-material.adoc
@@ -1,4 +1,11 @@
 ////
+Pantheon v2 extracts some information from variables defined in the document content. These variables must be defined at the header level (not at the body level); otherwise, Pantheon v2 cannot extract them.
+
+As of this writing, the only such variable is `:_module-type:`, but future development may introduce other such variables as well.
+////
+:_module-type: ASSEMBLY
+
+////
 Base the file name and the ID on the module title. For example:
 * file name: ref-my-reference-a.adoc
 * ID: [id="ref-my-reference-a_{context}"]


### PR DESCRIPTION
The current Pantheon v2 migration checklist lists the _module-type flag as a requirement, but this did not yet appear in the template. Placing in what I think is the appropriate location in the template files; please edit as required.