### PR TITLE
Add line about leveloffset.

### DIFF
--- a/modular-docs-manual/content/topics/module_guidelines-assembly.adoc
+++ b/modular-docs-manual/content/topics/module_guidelines-assembly.adoc
@@ -27,7 +27,7 @@ Use the second level heading syntax for the Prerequisites section in the assembl
 [discrete]
 == Assembly Modules
 
-List link:http://asciidoctor.org/docs/asciidoc-syntax-quick-reference/#include-files[include files] to include the required modules. Use any combination of concept, procedure, and reference modules that fulfills the purpose of the assembly.
+List link:http://asciidoctor.org/docs/asciidoc-syntax-quick-reference/#include-files[include files] to include the required modules. Use any combination of concept, procedure, and reference modules that fulfills the purpose of the assembly. A `leveloffset` can provide a method of introducing hierarchy, such as `module-file.adoc[leveloffset=+2]`.
 
 [discrete]
 == Assembly Additional Resources

--- a/modular-docs-manual/content/topics/module_guidelines-assembly.adoc
+++ b/modular-docs-manual/content/topics/module_guidelines-assembly.adoc
@@ -27,7 +27,16 @@ Use the second level heading syntax for the Prerequisites section in the assembl
 [discrete]
 == Assembly Modules
 
-List link:http://asciidoctor.org/docs/asciidoc-syntax-quick-reference/#include-files[include files] to include the required modules. Use any combination of concept, procedure, and reference modules that fulfills the purpose of the assembly. You can use a `leveloffset` attribute to set the hierarchy of the module relative to the assembly. In most cases, create modules whose title is an H1 and include those modules by using the format `module-file.adoc[leveloffset=+1]`. Otherwise, if necessary, you can use other `leveloffset` values, such as `module-file.adoc[leveloffset=+2]`, to modify the structure of your module content.
+To include modules in an assembly, use the Asciidoc  link:http://asciidoctor.org/docs/asciidoc-syntax-quick-reference/#include-files[include directive]. Use any combination of concept, procedure, and reference modules that fulfills the purpose of the assembly. Use the `leveloffset` attribute to set the hierarchy of the module relative to the assembly, as shown in the following example:
+
+.Level offset for module files
+----
+file1.adoc[leveloffset=+1]
+file2.adoc[leveloffset=+2]
+file3.adoc[leveloffset=+3]
+----
+
+NOTE: All module and assembly titles must use the H1 heading designation (`=`).
 
 [discrete]
 == Assembly Additional Resources

--- a/modular-docs-manual/content/topics/module_guidelines-assembly.adoc
+++ b/modular-docs-manual/content/topics/module_guidelines-assembly.adoc
@@ -27,7 +27,7 @@ Use the second level heading syntax for the Prerequisites section in the assembl
 [discrete]
 == Assembly Modules
 
-List link:http://asciidoctor.org/docs/asciidoc-syntax-quick-reference/#include-files[include files] to include the required modules. Use any combination of concept, procedure, and reference modules that fulfills the purpose of the assembly. A `leveloffset` can provide a method of introducing hierarchy, such as `module-file.adoc[leveloffset=+2]`.
+List link:http://asciidoctor.org/docs/asciidoc-syntax-quick-reference/#include-files[include files] to include the required modules. Use any combination of concept, procedure, and reference modules that fulfills the purpose of the assembly. You can use a `leveloffset` attribute, such as `module-file.adoc[leveloffset=+1]` or `module-file.adoc[leveloffset=+2]`, to set the hierarchy of the module relative to the assembly.
 
 [discrete]
 == Assembly Additional Resources

--- a/modular-docs-manual/content/topics/module_guidelines-assembly.adoc
+++ b/modular-docs-manual/content/topics/module_guidelines-assembly.adoc
@@ -36,7 +36,7 @@ file2.adoc[leveloffset=+2]
 file3.adoc[leveloffset=+3]
 ----
 
-NOTE: All module and assembly titles must use the H1 heading designation (`=`).
+All module and assembly titles must use the H1 heading designation, such as `= My heading`.
 
 [discrete]
 == Assembly Additional Resources

--- a/modular-docs-manual/content/topics/module_guidelines-assembly.adoc
+++ b/modular-docs-manual/content/topics/module_guidelines-assembly.adoc
@@ -27,7 +27,7 @@ Use the second level heading syntax for the Prerequisites section in the assembl
 [discrete]
 == Assembly Modules
 
-List link:http://asciidoctor.org/docs/asciidoc-syntax-quick-reference/#include-files[include files] to include the required modules. Use any combination of concept, procedure, and reference modules that fulfills the purpose of the assembly. You can use a `leveloffset` attribute, such as `module-file.adoc[leveloffset=+1]` or `module-file.adoc[leveloffset=+2]`, to set the hierarchy of the module relative to the assembly.
+List link:http://asciidoctor.org/docs/asciidoc-syntax-quick-reference/#include-files[include files] to include the required modules. Use any combination of concept, procedure, and reference modules that fulfills the purpose of the assembly. You can use a `leveloffset` attribute to set the hierarchy of the module relative to the assembly. In most cases, create modules whose title is an H1 and include those modules by using the format `module-file.adoc[leveloffset=+1]`. Otherwise, if necessary, you can use other `leveloffset` values, such as `module-file.adoc[leveloffset=+2]`, to modify the structure of your module content.
 
 [discrete]
 == Assembly Additional Resources


### PR DESCRIPTION
Addresses #112 . Apparently there has historically been a misunderstanding among CCS teammates that leveloffset is prohibited in mod docs. @pwright as part of his submitted issue suggested the simple added text shown in this PR to clarify that. The issue is already addressed in the assembly template itself here: https://raw.githubusercontent.com/redhat-documentation/modular-docs/master/modular-docs-manual/files/TEMPLATE_ASSEMBLY_a-collection-of-modules.adoc, so this small text addition should remove all doubt and close the loop. 

I realize that we're trying to avoid getting into ascii syntax suggestions etc. as part of mod docs, but Paul made a strong case that there is confusion out there. So if this clarifies that, then seems to deserve the mention.