### PR TITLE
Escape include directive in snippets example

### DIFF
--- a/modular-docs-manual/content/topics/using-text-snippets.adoc
+++ b/modular-docs-manual/content/topics/using-text-snippets.adoc
@@ -17,5 +17,5 @@ NOTE: Consider storing snippet files in a separate snippets folder.
 +
 [source]
 ----
-include::snippets/beta-note.adoc[]
+\include::snippets/beta-note.adoc[]
 ----


### PR DESCRIPTION
The ["Text Snippets"](https://redhat-documentation.github.io/modular-docs/#using-text-snippets) example block is currently attempting to parse the `include::` statement, so it renders as:

```
Unresolved directive in content/topics/using-text-snippets.adoc - include::snippets/beta-note.adoc[]
```

Per https://docs.asciidoctor.org/asciidoc/latest/directives/include/#escaping-an-include-directive, escape the include directive with a backslash to show up verbatim, as intended.

cc @sterobin since I saw you were interested in this section recently too via https://github.com/redhat-documentation/modular-docs/pull/180.