### PR TITLE
Updated the _module-type variable to _content-type per Jupiter guidelines

### DIFF
--- a/modular-docs-manual/content/topics/module_anchor-and-file-names-concept.adoc
+++ b/modular-docs-manual/content/topics/module_anchor-and-file-names-concept.adoc
@@ -31,9 +31,11 @@ These file naming guidelines are optional but highly recommended. However, if yo
 
 [source]
 ----
-:_module-type: CONCEPT
-:_module-type: PROCEDURE
-:_module-type: REFERENCE
+:_content-type: ASSEMBLY
+:_content-type: PROCEDURE
+:_content-type: CONCEPT
+:_content-type: REFERENCE
+:_content-type: SNIPPET
 ----
 
 .Anchors


### PR DESCRIPTION
[Jupiter guidelines](https://docs.engineering.redhat.com/display/JUP/Jupiter+Source+files+readiness+Checklist) recommend using `:_content-type` variable.
This PR updates the Modular documentation guideline to comply with the Jupiter guideline. It also adds two other `:_content-type` variable (ASSEMBLY and SNIPPETS).