### PR TITLE
Revert "Clarify Next steps"

### DIFF
--- a/modular-docs-manual/content/topics/creating_procedure_modules.adoc
+++ b/modular-docs-manual/content/topics/creating_procedure_modules.adoc
@@ -2,7 +2,7 @@
 
 = Procedure modules
 
-Procedure modules explain how to do something. A procedure module contains numbered, step-by-step instructions to help the user accomplish a single task. Sometimes those tasks include substeps. Procedure modules must include a title, a brief introduction, and one or more steps in the form of imperative statements. Procedure modules can also contain prerequisites, verification steps, additional resources, and next steps.
+Procedure modules explain how to do something. A procedure module contains numbered, step-by-step instructions to help the user accomplish a single task. Sometimes those tasks include substeps. Procedure modules must include a title, a brief introduction, and one or more steps in the form of imperative statements. Procedure modules can also contain prerequisites, verification steps, and additional resources or next steps.
 
 .Schema of a procedure module
 image::procedure-diagram.png[]
@@ -40,9 +40,6 @@ This section is optional. It provides the user with one or more steps to verify 
 This section is optional. The additional resources list links to other material closely related to the contents of the procedure module, such as other documentation resources, instructional videos, or labs.
 
 Focus on relevant resources that might interest the user. Do not list resources for completeness. If a resource applies to all of the modules in a user story, consider listing the resource in the Additional resources section of the assembly file. If you do this, consider including the resource in the procedure module as a comment.
-
-.Procedure next steps
-This section is optional. You can use it for directing the reader to tasks that might follow after the current procedure. Place this section after the *Additional resources* section and use the *Next steps* heading. Alternatively, if the user must perform the next steps before the verification steps, place the section between the *Procedure* section and the *Verification* section.
 
 == Additional resources
 


### PR DESCRIPTION
Reverts redhat-documentation/modular-docs#202

I'm sorry for giving my approval without being more thorough, it makes no sense to have next steps before verification, they should be after verification.