### PR TITLE
Add a "What's new" section to the Mod Docs standard

### DIFF
--- a/modular-docs-manual/content/modular-doc-manual.adoc
+++ b/modular-docs-manual/content/modular-doc-manual.adoc
@@ -2,9 +2,12 @@
 include::topics/introduction.adoc[leveloffset=+1]
 
 // Chapter 2
-include::topics/understanding-mod-docs.adoc[leveloffset=+1]
+include::topics/whats-new.adoc[leveloffset=+1]
 
 // Chapter 3
+include::topics/understanding-mod-docs.adoc[leveloffset=+1]
+
+// Chapter 4
 include::topics/writing-mod-docs.adoc[leveloffset=+1]
 
 // Appendices

--- a/modular-docs-manual/content/topics/whats-new.adoc
+++ b/modular-docs-manual/content/topics/whats-new.adoc
@@ -1,0 +1,17 @@
+[id="whats-new_{context}"]
+= What's new
+
+The following list summarizes significant changes to the modular documentation standard over time.
+
+For a complete list of changes, see link:https://github.com/redhat-documentation/modular-docs/pulls?q=is%3Apr+is%3Aclosed[the merged pull requests].
+
+// Release notes template:
+// == <year>: <month>
+//
+// * <Brief description of change. Include an inline link to the relevant section of the guide.>
+// link:<URL of the GitHub issue associated with this change>
+
+== 2023: August
+
+* Updated the name of the content type attribute in the templates from `:_content-type:` to `:_mod-docs-content-type:`.
+link:https://github.com/redhat-documentation/modular-docs/issues/203[#203]


### PR DESCRIPTION
Proposed fix for: Modular docs should have versioned releases #127
Fixes: #127
