### PR TITLE
Fix broken links in the examples, replace some

### DIFF
--- a/modular-docs-manual/content/topics/module_mod-docs-assembly-examples.adoc
+++ b/modular-docs-manual/content/topics/module_mod-docs-assembly-examples.adoc
@@ -5,4 +5,4 @@ link:https://access.redhat.com/documentation/en-us/red_hat_process_automation_ma
 
 link:https://access.redhat.com/documentation/en-us/red_hat_process_automation_manager/7.8/html-single/designing_a_decision_service_using_spreadsheet_decision_tables/index[Designing a decision service using spreadsheet decision tables]
 
-link:https://access.redhat.com/documentation/en-us/red_hat_build_of_quarkus/1.3/html-single/getting_started_with_red_hat_build_of_quarkus/index[Getting started with Red Hat Build of Quarkus]
+link:https://access.redhat.com/documentation/en-us/red_hat_build_of_quarkus/quarkus-3.2/guide/00b48021-40c0-40d8-95e6-64292948cf6f[Getting started with Red Hat Build of Quarkus]

--- a/modular-docs-manual/content/topics/module_mod-docs-concept-examples.adoc
+++ b/modular-docs-manual/content/topics/module_mod-docs-concept-examples.adoc
@@ -1,8 +1,8 @@
 [id="modular-docs-concept-examples"]
 = Concept module examples
 
-link:https://access.redhat.com/documentation/en-us/red_hat_process_automation_manager/7.8/html-single/creating_red_hat_process_automation_manager_business_applications_with_spring_boot/index#bus_app_business-applications[Red Hat Process Automation Manager business applications]
+link:https://access.redhat.com/documentation/en-us/red_hat_process_automation_manager/7.8/html/creating_red_hat_process_automation_manager_business_applications_with_spring_boot/bus_app_business-applications[Red Hat Process Automation Manager business applications]
 
-link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.5/html-single/architecture/index#cicd_gitops_methodology[The GitOps methodology and practice]
+link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.5/html/architecture/cicd_gitops#cicd_gitops_methodology[The GitOps methodology and practice]
 
-link:https://access.redhat.com/documentation/en-us/red_hat_amq/7.2/html-single/using_amq_online_on_openshift_container_platform/index#con-intro-roles-using-messaging[AMQ Online user roles]
+link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/using_selinux/getting-started-with-selinux_using-selinux#introduction-to-selinux_getting-started-with-selinux[Introduction to SELinux]

--- a/modular-docs-manual/content/topics/module_mod-docs-procedure-examples.adoc
+++ b/modular-docs-manual/content/topics/module_mod-docs-procedure-examples.adoc
@@ -1,8 +1,8 @@
 [id="modular-docs-procedure-examples"]
 = Procedure module examples
 
-link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.5/html-single/installing/index#installation-mirror-repository_installing-restricted-networks-preparations[Mirroring the OpenShift Container Platform image repository]
+link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_blocking-and-allowing-applications-using-fapolicyd_security-hardening#marking-files-as-trusted-using-an-additional-source-of-trust_assembly_blocking-and-allowing-applications-using-fapolicyd[Marking files as trusted using an additional source of trust]
 
-link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/using_containerized_identity_management_services/uninstalling-sssd-containers#uninstalling-sssd-containers-uninstalling-an-sssd-container-enrolled-in-an-ipa-domain[Uninstalling an SSSD Container Enrolled in an Identity Management Domain]
+link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.5/html/installing/installing-mirroring-installation-images#installation-mirror-repository_installing-mirroring-installation-images[Mirroring the OpenShift Container Platform image repository]
 
 link:https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/3/html/container_guide/administering-ceph-clusters-that-run-in-containers#purging-clusters-deployed-by-ansible[Purging Clusters Deployed by Ansible]

--- a/modular-docs-manual/content/topics/module_mod-docs-reference-examples.adoc
+++ b/modular-docs-manual/content/topics/module_mod-docs-reference-examples.adoc
@@ -4,7 +4,6 @@
 
 link:https://access.redhat.com/documentation/en-us/red_hat_ceph_storage/3/html/container_guide/changes-in-ansible-variables-between-version-2-and-3-container[Changes in Ansible Variables Between Version 2 and 3]
 
-link:https://access.redhat.com/documentation/en-us/red_hat_amq/7.2/html-single/using_amq_online_on_openshift_container_platform/#retrieving-address-space-information-messaging[Example commands for retrieving address space information]
+link:https://access.redhat.com/documentation/en-us/red_hat_amq_broker/7.11/html/deploying_amq_broker_on_openshift/reference-broker-ocp-broker-ocp#addressing-crd_broker-ocp[Address Custom Resource configuration reference]
 
-
-link:https://access.redhat.com/documentation/en-us/red_hat_process_automation_manager/7.8/html-single/interacting_with_red_hat_process_automation_manager_using_kie_apis/index#ejb-api-services-ref_kie-apis[Supported EJB services]
+link:https://access.redhat.com/documentation/en-us/red_hat_process_automation_manager/7.8/html/interacting_with_red_hat_process_automation_manager_using_kie_apis/ejb-api-con_kie-apis#ejb-api-services-ref_kie-apis[Supported EJB services]


### PR DESCRIPTION
Fixes https://github.com/redhat-documentation/modular-docs/issues/213

Additionally:
- fixes some other broken links (404s)
- replaces some not so good examples that included self-referential texts (for example)
- changes html-single to html-multi in module examples