### PR TITLE
Added a complete list of supported block titles

### DIFF
--- a/modular-docs-manual/files/TEMPLATE_PROCEDURE_doing-one-procedure.adoc
+++ b/modular-docs-manual/files/TEMPLATE_PROCEDURE_doing-one-procedure.adoc
@@ -41,7 +41,18 @@ Write a short introductory paragraph that provides an overview of the module. Th
 NOTE: You can add text, tables, code examples, images, and other items to a step. However, these items must be connected to the step with a plus sign (+). Any items under the .Procedure heading and before one of the following approved headings that are not connected to the last step with a plus sign cannot be converted to DITA.
 
 ////
-Only the following block headings can be reliably mapped to DITA: Prerequisites, Procedure, Verification, Troubleshooting, Troubleshooting steps, Next steps, Next step, Additional resources. They must appear in this order and, with the exception of Additional resources, are only allowed in a procedure module. You can also use block headings in figure, table, and example titles.
+Only the following block titles can be reliably mapped to DITA:
+
+* Prerequisites or Prerequisite
+* Procedure
+* Verification, Results, or Result
+* Troubleshooting, Troubleshooting steps, or Troubleshooting step
+* Next steps or Next step
+* Additional resources
+
+With the exception of Additional resources, these titles are only allowed in a procedure module. You can use each title exactly once and cannot use two different variants of the same title in the same module.
+
+Additionally, you can use block titles for figures, tables, and example blocks.
 ////
 
 .Verification


### PR DESCRIPTION
This is the definitive list of titles that are recognized during the DITA conversion and mapped to the corresponding `<prereq>`, `<step>`/`<steps-unordered>`, `<result>`, `<tasktroubleshooting>`, `<postreq>`, and `<related-links>` elements. It also matches the [corresponding vale rule](https://github.com/jhradilek/asciidoctor-dita-vale) that can be used to report unsupported block titles in procedures.

I have also removed the mention that these need to be in this order because while it makes sense and DITA insists on this order, the conversion tooling actually maps them correctly regardless in what order they appear. This re-shuffling is necessary because any contents preceding the first block title in AsciiDoc is mapped to `<context>` and while in our documentation it comes first, in DITA it appears after the `<prereq>` element.