### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       - name: Extract assets
         run: docker cp $(docker run --detach quay.io/redhat-docs/redhat-docs-template):/assets ./modular-docs-manual/assets
       - name: Build AsciiDoc
@@ -43,11 +43,11 @@ jobs:
           cp -r modular-docs-manual/images/ docs/images
           mv index.html docs/
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v4
         with:
           path: './docs'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for deploying the site by upgrading several GitHub Actions to their latest major versions. These updates help ensure continued support, security, and access to the latest features.

Workflow dependency upgrades:

* Updated `actions/checkout` from version 3 to version 5 in `.github/workflows/deploy-site.yml`.
* Updated `actions/configure-pages` from version 3 to version 5 in `.github/workflows/deploy-site.yml`.
* Updated `actions/upload-pages-artifact` from version 1 to version 4 in `.github/workflows/deploy-site.yml`.
* Updated `actions/deploy-pages` from version 2 to version 4 in `.github/workflows/deploy-site.yml`.

Fixes #246 